### PR TITLE
Fix admin guard casting and refresh tests

### DIFF
--- a/api/Filters/AdminGuardAttribute.cs
+++ b/api/Filters/AdminGuardAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using api.Models; // for User
+using api.Middleware; // for CurrentUser extension
 
 namespace api.Filters
 {
@@ -22,8 +22,8 @@ namespace api.Filters
                 (http.Request.Host.Host?.Equals("localhost", StringComparison.OrdinalIgnoreCase) ?? false);
 
             // 2) User.IsAdmin check (set by your UserContextMiddleware)
-            var userObj = http.Items.TryGetValue("User", out var u) ? u as User : null;
-            var isAdmin = userObj?.IsAdmin == true;
+            var currentUser = http.GetCurrentUser();
+            var isAdmin = currentUser?.IsAdmin == true;
 
             if (isLocal || isAdmin)
             {

--- a/api/Models/Card.cs
+++ b/api/Models/Card.cs
@@ -5,7 +5,7 @@
         public int Id { get; set; }
         public required string Game { get; set; } // Magic, Lorcana, Star Wars Unlimited etc..
         public required string Name { get; set; } // Name of card
-        public required string CardType { get; set; } // Unit, Instant, Sorcery, Upgrade, Enchatment etc..
+        public required string CardType { get; set; } // Unit, Instant, Sorcery, Upgrade, Enchantment etc..
         public string? Description { get; set; } // Optional rules text
         public ICollection<CardPrinting> Printings { get; set; } = new List<CardPrinting>();
     }

--- a/api/api.http
+++ b/api/api.http
@@ -1,6 +1,7 @@
 @api_HostAddress = http://localhost:5229
 
-GET {{api_HostAddress}}/weatherforecast/
+### Retrieve all cards
+GET {{api_HostAddress}}/api/card
 Accept: application/json
 
 ###

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,34 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  jest.resetAllMocks();
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+});
+
+test('renders cards fetched from the API', async () => {
+  const mockCards = [
+    { id: 1, name: 'Black Lotus', game: 'Magic: The Gathering' },
+    { id: 2, name: 'Elsa, Snow Queen', game: 'Lorcana' }
+  ];
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => mockCards
+  });
+
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  expect(screen.getByRole('heading', { name: /cards from api/i })).toBeInTheDocument();
+  expect(global.fetch).toHaveBeenCalledWith('/api/card');
+
+  for (const card of mockCards) {
+    expect(await screen.findByText(`${card.name} (${card.game})`)).toBeInTheDocument();
+  }
 });


### PR DESCRIPTION
## Summary
- update `AdminGuardAttribute` to read the `CurrentUser` record stored by the middleware so admin requests succeed when authenticated
- correct the "Enchantment" typo in the card model and refresh the HTTP scratch file to reference the `/api/card` endpoint
- rewrite the React unit test to mock the cards API and assert against the real UI output

## Testing
- npm --no-progress ci *(fails: 403 Forbidden when downloading tsutils from the npm registry)*
- dotnet build api/api.sln *(fails: dotnet CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d161a50910832f867b2c215fbf53c1