### PR TITLE
Configure Vite dev proxy to ASP.NET API

### DIFF
--- a/client-vite/vite.config.ts
+++ b/client-vite/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://localhost:7226',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure the Vite dev server to proxy /api requests to the ASP.NET backend

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2b4fe5af4832fb393c4d7352de81a