### PR TITLE
Add Vite dev origin to CORS policy

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowReact",
-        b => b.WithOrigins("http://localhost:3000")
+        b => b.WithOrigins("http://localhost:3000", "http://localhost:5173")
               .AllowAnyMethod()
               .AllowAnyHeader());
 });


### PR DESCRIPTION
## Summary
- Add Vite dev origin (5173) to CORS ‘AllowReact’ policy.


------
https://chatgpt.com/codex/tasks/task_e_68d2ba771df0832f82ea852d9c1f7fda