### PR TITLE
Fix card printing updates and add tests

### DIFF
--- a/api.Tests/CardControllerTests.cs
+++ b/api.Tests/CardControllerTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using api.Controllers;
+using api.Data;
+using api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace api.Tests;
+
+public class CardControllerTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: $"cards_{Guid.NewGuid()}")
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task Update_PreservesNewPrintings()
+    {
+        await using var context = CreateContext();
+
+        var card = new Card
+        {
+            Game = "Test Game",
+            Name = "Test Card",
+            CardType = "Spell",
+            Description = "A test card",
+            Printings = new List<CardPrinting>
+            {
+                new CardPrinting
+                {
+                    Set = "Base",
+                    Number = "001",
+                    Rarity = "Common",
+                    Style = "Standard",
+                    ImageUrl = "http://example.com/base"
+                }
+            }
+        };
+
+        context.Cards.Add(card);
+        await context.SaveChangesAsync();
+
+        var existingPrinting = card.Printings.Single();
+
+        var controller = new CardController(context);
+        var updateDto = new UpdateCardDto(
+            card.Game,
+            card.Name,
+            card.CardType,
+            card.Description,
+            new List<UpdateCardPrintingDto>
+            {
+                new(existingPrinting.Id, existingPrinting.Set, existingPrinting.Number, existingPrinting.Rarity, existingPrinting.Style, existingPrinting.ImageUrl),
+                new(null, "Expansion", "010", "Rare", "Foil", "http://example.com/expansion")
+            }
+        );
+
+        var result = await controller.Update(card.Id, updateDto);
+
+        Assert.IsType<NoContentResult>(result);
+
+        var updatedCard = await context.Cards.Include(c => c.Printings).SingleAsync(c => c.Id == card.Id);
+
+        Assert.Equal(2, updatedCard.Printings.Count);
+        Assert.Contains(updatedCard.Printings, p => p.Id == existingPrinting.Id);
+        Assert.Contains(updatedCard.Printings, p => p.Set == "Expansion" && p.Number == "010");
+    }
+}

--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\api\api.csproj" />
+  </ItemGroup>
+</Project>

--- a/api/Controllers/CardController.cs
+++ b/api/Controllers/CardController.cs
@@ -119,6 +119,7 @@ namespace api.Controllers
             // Replace printings: update matching by Id, add new where Id is null, remove missing
             var incoming = dto.Printings ?? new();
             var byId = card.Printings.ToDictionary(p => p.Id);
+            var existingPrintings = card.Printings.ToList();
 
             // mark all existing as unseen
             var seen = new HashSet<int>();
@@ -145,7 +146,7 @@ namespace api.Controllers
             }
 
             // delete any not seen
-            var toRemove = card.Printings.Where(p => !seen.Contains(p.Id) && incoming.All(x => x.Id != p.Id)).ToList();
+            var toRemove = existingPrintings.Where(p => !seen.Contains(p.Id)).ToList();
             foreach (var r in toRemove) _db.CardPrintings.Remove(r);
 
             await _db.SaveChangesAsync();

--- a/api/Controllers/CollectionController.cs
+++ b/api/Controllers/CollectionController.cs
@@ -146,7 +146,7 @@ namespace api.Controllers
             return NoContent();
         }
 
-        // Set both quantities
+        // Set owned, wanted, and proxy quantities in one request
         [HttpPut("{cardPrintingId:int}")]
         public async Task<IActionResult> SetQuantities(int userId, int cardPrintingId, [FromBody] SetQuantitiesDto dto)
         {

--- a/api/api.sln
+++ b/api/api.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.14.36221.1 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api", "api.csproj", "{66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api.Tests", "..\\api.Tests\\api.Tests.csproj", "{97FF5972-24A1-46B4-8A6C-B1C0566B9810}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {66FB4022-EDDF-4EE2-B9D0-857E2A1CC8A5}.Release|Any CPU.Build.0 = Release|Any CPU
+                {97FF5972-24A1-46B4-8A6C-B1C0566B9810}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {97FF5972-24A1-46B4-8A6C-B1C0566B9810}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {97FF5972-24A1-46B4-8A6C-B1C0566B9810}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {97FF5972-24A1-46B4-8A6C-B1C0566B9810}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- prevent newly added printings from being removed during `CardController.Update`
- clarify the `CollectionController.SetQuantities` comment to describe all three quantities
- add an EF Core in-memory test project that verifies the update flow preserves new printings

## Testing
- `dotnet test api/api.sln` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d490092c80832f82053e483fdc4bc6