### PR TITLE
Add admin upload endpoints for file imports

### DIFF
--- a/api/Controllers/AdminUploadController.cs
+++ b/api/Controllers/AdminUploadController.cs
@@ -37,7 +37,8 @@ public sealed class AdminUploadController : ControllerBase
         using var ms = new MemoryStream();
         await s.CopyToAsync(ms, ct);
         ms.Position = 0;
-        using var p = new TextFieldParser(ms) { TextFieldType = FieldType.Delimited };
+        using var parserStream = new MemoryStream(ms.ToArray(), writable: false);
+        using var p = new TextFieldParser(parserStream) { TextFieldType = FieldType.Delimited };
         p.SetDelimiters(",");
         if (p.EndOfData) return BadRequest(new { error = "Empty CSV." });
         var header = p.ReadFields() ?? Array.Empty<string>();


### PR DESCRIPTION
## Summary
- add an AdminUploadController that supports CSV and JSON upload endpoints for registered importers
- validate minimum schema requirements for incoming CSV and JSON files before dispatching to the importer
- forward dry-run, limit, and user context options when invoking ImportFromFileAsync

## Testing
- dotnet test api/api.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b946b550832f87a47c6fbce7f162