### PR TITLE
Fix value refresh ignored count and add coverage

### DIFF
--- a/api.Tests/ValueControllerTests.cs
+++ b/api.Tests/ValueControllerTests.cs
@@ -1,0 +1,100 @@
+// Run these tests with `dotnet test` or from Visual Studio Test Explorer.
+// Covers /api/value endpoints including refresh and collection summary calculations.
+
+using System.Linq;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using api.Data;
+using api.Models;
+using api.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace api.Tests;
+
+public class ValueControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+
+    public ValueControllerTests(CustomWebApplicationFactory factory) => _factory = factory;
+
+    private sealed record RefreshResponse(int inserted, int ignored);
+
+    private sealed record CollectionSummaryResponse(long totalCents, GameSliceResponse[] byGame);
+
+    private sealed record GameSliceResponse(string game, long cents);
+
+    [Fact]
+    public async Task Value_Refresh_CountsDuplicateValidRowsAndInvalidOnesSeparately()
+    {
+        await _factory.ResetDatabaseAsync();
+        using var client = _factory.CreateClient();
+
+        var payload = new[]
+        {
+            new { cardPrintingId = TestDataSeeder.LightningBoltAlphaPrintingId, priceCents = 1000L, source = "test" },
+            new { cardPrintingId = TestDataSeeder.LightningBoltAlphaPrintingId, priceCents = 1100L, source = (string?)null },
+            new { cardPrintingId = 999999, priceCents = 9999L, source = "invalid" },
+            new { cardPrintingId = TestDataSeeder.ElsaPrintingId, priceCents = 2000L, source = "wrong-game" }
+        };
+
+        var response = await client.PostAsJsonAsync("/api/value/refresh?game=Magic", payload);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<RefreshResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.inserted);
+        Assert.Equal(2, result.ignored);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var histories = await db.ValueHistories
+            .Where(v => v.ScopeType == ValueScopeType.CardPrinting && v.ScopeId == TestDataSeeder.LightningBoltAlphaPrintingId)
+            .OrderBy(v => v.PriceCents)
+            .ToListAsync();
+
+        Assert.Equal(2, histories.Count);
+        Assert.Collection(
+            histories,
+            h => Assert.Equal(1000L, h.PriceCents),
+            h => Assert.Equal(1100L, h.PriceCents));
+    }
+
+    [Fact]
+    public async Task Value_CollectionSummary_UsesLatestPricesPerGame()
+    {
+        await _factory.ResetDatabaseAsync();
+        using var unauthenticated = _factory.CreateClient();
+
+        var magicPrices = new[]
+        {
+            new { cardPrintingId = TestDataSeeder.LightningBoltAlphaPrintingId, priceCents = 1234L, source = "initial" },
+            new { cardPrintingId = TestDataSeeder.GoblinGuidePrintingId, priceCents = 4321L, source = "initial" }
+        };
+        var magicResponse = await unauthenticated.PostAsJsonAsync("/api/value/refresh?game=Magic", magicPrices);
+        magicResponse.EnsureSuccessStatusCode();
+
+        var lorcanaPrices = new[]
+        {
+            new { cardPrintingId = TestDataSeeder.ElsaPrintingId, priceCents = 5678L, source = "initial" },
+            new { cardPrintingId = TestDataSeeder.MickeyPrintingId, priceCents = 8765L, source = "initial" }
+        };
+        var lorcanaResponse = await unauthenticated.PostAsJsonAsync("/api/value/refresh?game=Lorcana", lorcanaPrices);
+        lorcanaResponse.EnsureSuccessStatusCode();
+
+        using var client = _factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+        var summary = await client.GetFromJsonAsync<CollectionSummaryResponse>("/api/value/collection/summary");
+
+        Assert.NotNull(summary);
+        var expectedMagic = 1234L * 5; // Alice owns five Lightning Bolt Alpha copies
+        var expectedLorcana = 5678L * 1; // Alice owns one Elsa printing
+        Assert.Equal(expectedMagic + expectedLorcana, summary!.totalCents);
+
+        var magicSlice = Assert.Single(summary.byGame.Where(s => s.game == "Magic"));
+        Assert.Equal(expectedMagic, magicSlice.cents);
+
+        var lorcanaSlice = Assert.Single(summary.byGame.Where(s => s.game == "Lorcana"));
+        Assert.Equal(expectedLorcana, lorcanaSlice.cents);
+    }
+}

--- a/api/Controllers/AdminUploadController.cs
+++ b/api/Controllers/AdminUploadController.cs
@@ -70,7 +70,7 @@ public sealed class AdminUploadController : ControllerBase
 
         await using var s = file.OpenReadStream();
 
-        // Schema check: array of objects; each must have set+number+name (sample first 100)
+        // Schema check: array of objects; each must have set/set_code + number/collector_number + name (sample first 100)
         using var doc = await JsonDocument.ParseAsync(s, cancellationToken: ct);
         if (doc.RootElement.ValueKind != JsonValueKind.Array) return BadRequest(new { error = "Top-level JSON must be an array." });
         int idx = 0;

--- a/api/Controllers/ValueController.cs
+++ b/api/Controllers/ValueController.cs
@@ -53,7 +53,7 @@ public class ValueController : ControllerBase
 
         await _db.SaveChangesAsync();
         var inserted = items.Count(x => validSet.Contains(x.CardPrintingId));
-        var ignored = items.Count - validSet.Count;
+        var ignored = items.Count - inserted;
         return Ok(new { inserted, ignored });
     }
 


### PR DESCRIPTION
## Summary
- correct the ignored count reported by the value refresh endpoint so duplicate valid rows are counted properly
- clarify the JSON upload schema comment to mention the accepted set/number aliases
- add integration tests covering value refresh duplicate handling and collection summary aggregation

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c89399d0832fa8855d640086afdf