### PR TITLE
Remove unsupported cache mount from devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,5 @@
         "ms-azuretools.vscode-docker"
       ]
     }
-  },
-  "mounts": [
-    "type=cache,target=/root/.nuget/packages"
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- remove the cache-based mount from the devcontainer so Codespaces can start successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87b39c1c8832fa0f9ee000a748e32