### PR TITLE
Fix CurrentUser instantiation in admin guard tests

### DIFF
--- a/api.Tests/AdminGuardAttributeTests.cs
+++ b/api.Tests/AdminGuardAttributeTests.cs
@@ -42,7 +42,7 @@ public class AdminGuardAttributeTests
         var context = CreateContext(
             IPAddress.Parse("203.0.113.42"),
             includeLocalhostHostHeader: false,
-            user: new CurrentUser(1, "admin", isAdmin: true));
+            user: new CurrentUser(1, "admin", true));
 
         attribute.OnActionExecuting(context);
 


### PR DESCRIPTION
## Summary
- update the admin guard test to instantiate `CurrentUser` with positional arguments so it matches the record constructor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d8787660832fb2cd35b459d12fbf