### PR TITLE
Allow PATCH endpoints to accept JSON payloads

### DIFF
--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -275,6 +275,7 @@ public class CollectionsController : ControllerBase
     }
 
     [HttpPatch("{cardPrintingId:int}")]
+    [Consumes("application/json")]
     public async Task<IActionResult> PatchQuantities(int userId, int cardPrintingId, [FromBody] JsonElement updates)
     {
         if (UserMismatch(userId)) return StatusCode(403, "User mismatch.");
@@ -337,6 +338,7 @@ public class CollectionsController : ControllerBase
 
     [HttpPatch("/api/collection/{cardPrintingId:int}")]
     [HttpPatch("/api/collections/{cardPrintingId:int}")]
+    [Consumes("application/json")]
     public async Task<IActionResult> PatchQuantitiesForCurrent(int cardPrintingId, [FromBody] JsonElement updates)
     {
         if (!TryResolveCurrentUserId(out var uid, out var err)) return err!;

--- a/api/Features/Decks/DecksController.cs
+++ b/api/Features/Decks/DecksController.cs
@@ -450,6 +450,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}
     [HttpPatch("/api/deck/{deckId:int}")]
     [HttpPatch("/api/decks/{deckId:int}")] // alias
+    [Consumes("application/json")]
     public async Task<IActionResult> PatchDeck(int deckId, [FromBody] JsonElement updates) => await PatchDeckCore(deckId, updates);
 
     // PUT /api/deck/{deckId}
@@ -494,6 +495,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}/cards/{cardPrintingId}
     [HttpPatch("/api/deck/{deckId:int}/cards/{cardPrintingId:int}")]
     [HttpPatch("/api/decks/{deckId:int}/cards/{cardPrintingId:int}")] // alias
+    [Consumes("application/json")]
     public async Task<IActionResult> PatchDeckCardQuantities(int deckId, int cardPrintingId, [FromBody] JsonElement updates)
         => await PatchDeckCardQuantitiesCore(deckId, cardPrintingId, updates);
 


### PR DESCRIPTION
## Summary
- declare deck patch endpoints consume application/json bodies so JsonElement payloads bind correctly
- do the same for collection quantity patch routes to align with integration tests

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da892fc37c832f9903ef3d79e01bae