### PR TITLE
Support JSON media types for PATCH endpoints

### DIFF
--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Net.Mime;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -275,7 +276,7 @@ public class CollectionsController : ControllerBase
     }
 
     [HttpPatch("{cardPrintingId:int}")]
-    [Consumes("application/json")]
+    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
     public async Task<IActionResult> PatchQuantities(int userId, int cardPrintingId, [FromBody] JsonElement updates)
     {
         if (UserMismatch(userId)) return StatusCode(403, "User mismatch.");
@@ -338,7 +339,7 @@ public class CollectionsController : ControllerBase
 
     [HttpPatch("/api/collection/{cardPrintingId:int}")]
     [HttpPatch("/api/collections/{cardPrintingId:int}")]
-    [Consumes("application/json")]
+    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
     public async Task<IActionResult> PatchQuantitiesForCurrent(int cardPrintingId, [FromBody] JsonElement updates)
     {
         if (!TryResolveCurrentUserId(out var uid, out var err)) return err!;

--- a/api/Features/Decks/DecksController.cs
+++ b/api/Features/Decks/DecksController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using System.Text.Json;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
@@ -450,7 +451,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}
     [HttpPatch("/api/deck/{deckId:int}")]
     [HttpPatch("/api/decks/{deckId:int}")] // alias
-    [Consumes("application/json")]
+    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
     public async Task<IActionResult> PatchDeck(int deckId, [FromBody] JsonElement updates) => await PatchDeckCore(deckId, updates);
 
     // PUT /api/deck/{deckId}
@@ -495,7 +496,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}/cards/{cardPrintingId}
     [HttpPatch("/api/deck/{deckId:int}/cards/{cardPrintingId:int}")]
     [HttpPatch("/api/decks/{deckId:int}/cards/{cardPrintingId:int}")] // alias
-    [Consumes("application/json")]
+    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
     public async Task<IActionResult> PatchDeckCardQuantities(int deckId, int cardPrintingId, [FromBody] JsonElement updates)
         => await PatchDeckCardQuantitiesCore(deckId, cardPrintingId, updates);
 


### PR DESCRIPTION
## Summary
- allow deck PATCH endpoints to consume standard JSON media types instead of rejecting requests
- do the same for collection PATCH endpoints so partial updates accept typical JSON payloads

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da8c10ad04832fbd42795eef5b7df0