### PR TITLE
Allow JSON patch requests

### DIFF
--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
-using System.Net.Mime;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -276,7 +275,7 @@ public class CollectionsController : ControllerBase
     }
 
     [HttpPatch("{cardPrintingId:int}")]
-    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchQuantities(int userId, int cardPrintingId, [FromBody] JsonElement updates)
     {
         if (UserMismatch(userId)) return StatusCode(403, "User mismatch.");
@@ -339,7 +338,7 @@ public class CollectionsController : ControllerBase
 
     [HttpPatch("/api/collection/{cardPrintingId:int}")]
     [HttpPatch("/api/collections/{cardPrintingId:int}")]
-    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchQuantitiesForCurrent(int cardPrintingId, [FromBody] JsonElement updates)
     {
         if (!TryResolveCurrentUserId(out var uid, out var err)) return err!;

--- a/api/Features/Decks/DecksController.cs
+++ b/api/Features/Decks/DecksController.cs
@@ -1,4 +1,3 @@
-using System.Net.Mime;
 using System.Text.Json;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
@@ -451,7 +450,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}
     [HttpPatch("/api/deck/{deckId:int}")]
     [HttpPatch("/api/decks/{deckId:int}")] // alias
-    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchDeck(int deckId, [FromBody] JsonElement updates) => await PatchDeckCore(deckId, updates);
 
     // PUT /api/deck/{deckId}
@@ -496,7 +495,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}/cards/{cardPrintingId}
     [HttpPatch("/api/deck/{deckId:int}/cards/{cardPrintingId:int}")]
     [HttpPatch("/api/decks/{deckId:int}/cards/{cardPrintingId:int}")] // alias
-    [Consumes(MediaTypeNames.Application.Json, "application/*+json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchDeckCardQuantities(int deckId, int cardPrintingId, [FromBody] JsonElement updates)
         => await PatchDeckCardQuantitiesCore(deckId, cardPrintingId, updates);
 


### PR DESCRIPTION
## Summary
- allow deck and collection PATCH endpoints to accept standard application/json payloads without relying on MediaTypeNames
- remove unused System.Net.Mime imports now that the attribute uses literal content types

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da8fa0a6f4832fae19da07e6893ff8