### PR TITLE
Fix inconsistent proxies in test data seeding

### DIFF
--- a/api.Tests/Fixtures/TestDataSeeder.cs
+++ b/api.Tests/Fixtures/TestDataSeeder.cs
@@ -161,7 +161,7 @@ public static class TestDataSeeder
                 CardPrintingId = ElsaPrintingId,
                 QuantityOwned = 1,
                 QuantityWanted = 0,
-                QuantityProxyOwned = 0
+                QuantityProxyOwned = 1
             },
             new UserCard
             {
@@ -233,7 +233,7 @@ public static class TestDataSeeder
                 QuantityInDeck = 1,
                 QuantityIdea = 2,
                 QuantityAcquire = 1,
-                QuantityProxy = 0
+                QuantityProxy = 1
             },
             new DeckCard
             {
@@ -251,7 +251,7 @@ public static class TestDataSeeder
                 QuantityInDeck = 3,
                 QuantityIdea = 0,
                 QuantityAcquire = 0,
-                QuantityProxy = 0
+                QuantityProxy = 1
             }
         );
 


### PR DESCRIPTION
## Summary
- ensure Elsa's seeded collection includes a proxy copy to match her deck usage
- mark Lightning Bolt Beta and Goblin Guide deck entries as using proxies so counts align with collection data

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da93e7c240832f8661481235183250