### PR TITLE
Fix patch endpoints JSON body handling

### DIFF
--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -43,10 +43,9 @@ public class CollectionsController : ControllerBase
     {
         try
         {
-            if (Request.ContentLength.HasValue && Request.ContentLength == 0)
-                return (default, BadRequest(errorMessage));
-
             using var doc = await JsonDocument.ParseAsync(Request.Body);
+            if (doc.RootElement.ValueKind == JsonValueKind.Undefined)
+                return (default, BadRequest(errorMessage));
             return (doc.RootElement.Clone(), null);
         }
         catch (JsonException)

--- a/api/Features/Decks/DecksController.cs
+++ b/api/Features/Decks/DecksController.cs
@@ -41,10 +41,9 @@ public class DecksController : ControllerBase
     {
         try
         {
-            if (Request.ContentLength.HasValue && Request.ContentLength == 0)
-                return (default, BadRequest(errorMessage));
-
             using var doc = await JsonDocument.ParseAsync(Request.Body);
+            if (doc.RootElement.ValueKind == JsonValueKind.Undefined)
+                return (default, BadRequest(errorMessage));
             return (doc.RootElement.Clone(), null);
         }
         catch (JsonException)


### PR DESCRIPTION
## Summary
- allow deck and collection patch helpers to parse JSON bodies without depending on the Content-Length header
- treat undefined JSON payloads as missing so the existing validation stays intact

## Testing
- Not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da97792b7c832f940be3a3fe08515c