### PR TITLE
Fix PATCH content-type handling

### DIFF
--- a/api/Features/Decks/DecksController.cs
+++ b/api/Features/Decks/DecksController.cs
@@ -524,6 +524,7 @@ public class DecksController : ControllerBase
     }
 
     [HttpPatch("{id:int}")]
+    [Consumes("application/json")]
     public async Task<IActionResult> Patch(int userId, int id, [FromBody] JsonElement patch)
     {
         if (UserMismatch(userId)) return Forbid();
@@ -563,6 +564,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}
     [HttpPatch("/api/deck/{deckId:int}")]
     [HttpPatch("/api/decks/{deckId:int}")]
+    [Consumes("application/json")]
     public async Task<IActionResult> PatchDeck(int deckId, [FromBody] JsonElement patch)
     {
         var (deck, error) = await GetDeckForCaller(deckId);
@@ -612,6 +614,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}/cards/{cardPrintingId}
     [HttpPatch("/api/deck/{deckId:int}/cards/{cardPrintingId:int}")]
     [HttpPatch("/api/decks/{deckId:int}/cards/{cardPrintingId:int}")]
+    [Consumes("application/json")]
     public async Task<IActionResult> PatchDeckCardQuantities(int deckId, int cardPrintingId, [FromBody] JsonElement patch)
         => await PatchDeckCardQuantitiesCore(deckId, cardPrintingId, patch);
 

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -36,7 +36,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowReact", p => p
         .WithOrigins("http://localhost:5173")
         .WithHeaders("X-User-Id", "Content-Type")
-        .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 });
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- declare JSON consumption on all DecksController PATCH endpoints to avoid 415 errors
- allow PATCH requests in the AllowReact CORS policy so the dev client can call them

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db767d2054832fb91859bdd66ed5f1