### PR TITLE
Allow JSON merge patch requests for deck APIs

### DIFF
--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -294,6 +294,7 @@ public class CollectionsController : ControllerBase
     }
 
     [HttpPatch("{cardPrintingId:int}")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchQuantities(int userId, int cardPrintingId, [FromBody] JsonElement patch)
     {
         if (UserMismatch(userId)) return Forbid();
@@ -355,6 +356,7 @@ public class CollectionsController : ControllerBase
 
     [HttpPatch("/api/collection/{cardPrintingId:int}")]
     [HttpPatch("/api/collections/{cardPrintingId:int}")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchQuantitiesForCurrent(int cardPrintingId, [FromBody] JsonElement patch)
     {
         if (!TryResolveCurrentUserId(out var uid, out var err)) return err!;

--- a/api/Features/Decks/DecksController.cs
+++ b/api/Features/Decks/DecksController.cs
@@ -524,7 +524,7 @@ public class DecksController : ControllerBase
     }
 
     [HttpPatch("{id:int}")]
-    [Consumes("application/json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> Patch(int userId, int id, [FromBody] JsonElement patch)
     {
         if (UserMismatch(userId)) return Forbid();
@@ -564,7 +564,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}
     [HttpPatch("/api/deck/{deckId:int}")]
     [HttpPatch("/api/decks/{deckId:int}")]
-    [Consumes("application/json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchDeck(int deckId, [FromBody] JsonElement patch)
     {
         var (deck, error) = await GetDeckForCaller(deckId);
@@ -614,7 +614,7 @@ public class DecksController : ControllerBase
     // PATCH /api/deck/{deckId}/cards/{cardPrintingId}
     [HttpPatch("/api/deck/{deckId:int}/cards/{cardPrintingId:int}")]
     [HttpPatch("/api/decks/{deckId:int}/cards/{cardPrintingId:int}")]
-    [Consumes("application/json")]
+    [Consumes("application/json", "application/*+json")]
     public async Task<IActionResult> PatchDeckCardQuantities(int deckId, int cardPrintingId, [FromBody] JsonElement patch)
         => await PatchDeckCardQuantitiesCore(deckId, cardPrintingId, patch);
 


### PR DESCRIPTION
## Summary
- allow all deck PATCH endpoints to consume JSON merge patch payloads by adding application/*+json
- align collection PATCH endpoints with the same JSON consumption rules

## Testing
- dotnet test api.Tests/api.Tests.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db78bf0ff8832f86ce78d4af17f2d4