### PR TITLE
Add dummy authentication scheme for forbid handling

### DIFF
--- a/api/Common/DummyAuthenticationHandler.cs
+++ b/api/Common/DummyAuthenticationHandler.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace api.Common;
+
+public sealed class DummyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "Dummy";
+
+    public DummyAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder,
+        ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var identity = new ClaimsIdentity(Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,8 +1,10 @@
+using api.Common;
 using api.Data;
 using api.Middleware;
 using api.Models;
 using api.Importing;
 using FluentValidation;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,6 +18,19 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlite("Data Source=app.db"));
 
 builder.Services.AddHttpClient();
+
+builder.Services
+    .AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = DummyAuthenticationHandler.SchemeName;
+        options.DefaultChallengeScheme = DummyAuthenticationHandler.SchemeName;
+        options.DefaultForbidScheme = DummyAuthenticationHandler.SchemeName;
+    })
+    .AddScheme<AuthenticationSchemeOptions, DummyAuthenticationHandler>(
+        DummyAuthenticationHandler.SchemeName,
+        _ => { });
+
+builder.Services.AddAuthorization();
 builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.ScryfallImporter>();
 builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.SwccgdbImporter>();
 builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.LorcanaJsonImporter>();
@@ -52,6 +67,7 @@ using (var scope = app.Services.CreateScope())
 // Pipeline
 app.UseHttpsRedirection();
 app.UseCors("AllowReact");
+app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<UserContextMiddleware>();
 


### PR DESCRIPTION
## Summary
- register a dummy authentication handler so Forbid() results are processed
- enable authentication middleware in the pipeline alongside authorization

## Testing
- dotnet test api.Tests/api.Tests.csproj --filter "DeckCards_AllEndpoints_EnforceOwnership_403WhenNotOwner" *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc757ac10832fbea2ab56adcf164e