### PR TITLE
Adjust dummy authentication handler to surface correct status codes

### DIFF
--- a/api/Common/DummyAuthenticationHandler.cs
+++ b/api/Common/DummyAuthenticationHandler.cs
@@ -1,6 +1,6 @@
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -20,10 +20,17 @@ public sealed class DummyAuthenticationHandler : AuthenticationHandler<Authentic
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        => Task.FromResult(AuthenticateResult.NoResult());
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
     {
-        var identity = new ClaimsIdentity(Scheme.Name);
-        var principal = new ClaimsPrincipal(identity);
-        var ticket = new AuthenticationTicket(principal, Scheme.Name);
-        return Task.FromResult(AuthenticateResult.Success(ticket));
+        Response.StatusCode = StatusCodes.Status401Unauthorized;
+        return Task.CompletedTask;
+    }
+
+    protected override Task HandleForbiddenAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = StatusCodes.Status403Forbidden;
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- update the dummy authentication handler to return no authentication result and explicitly set the status codes for challenge and forbid responses so 401/403 are surfaced consistently

## Testing
- dotnet test api.Tests/api.Tests.csproj *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcff9350c832f897c5ad4906d27a1