### PR TITLE
Refactor test JSON content creation

### DIFF
--- a/api.Tests/CollectionControllerTests.cs
+++ b/api.Tests/CollectionControllerTests.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Net.Http.Headers;
 using api.Tests.Helpers;
-using System.Text;
 using System.Text.Json;
 using api.Features.Collections.Dtos;
 using api.Tests.Fixtures;
@@ -196,10 +195,7 @@ public class CollectionControllerTests : IClassFixture<CustomWebApplicationFacto
                 HttpMethod.Patch,
                 $"/api/collection/{TestDataSeeder.LightningBoltBetaPrintingId}")
             {
-                Content = new StringContent(
-                    JsonSerializer.Serialize(new { quantityWanted = 4 }),
-                    Encoding.UTF8,
-                    "application/json")
+                Content = JsonContent.Create(new { quantityWanted = 4 })
             };
 
             var response = await client.SendAsync(patchReq);

--- a/api.Tests/DeckControllerTests.cs
+++ b/api.Tests/DeckControllerTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Text.Json;
 using api.Features.Decks.Dtos;
 using api.Tests.Fixtures;
@@ -77,10 +76,7 @@ public class DeckControllerTests : IClassFixture<CustomWebApplicationFactory>
     // PATCH with explicit application/json
     var patchReq = new HttpRequestMessage(HttpMethod.Patch, $"/api/deck/{deckId}")
     {
-        Content = new StringContent(
-            JsonSerializer.Serialize(new { description = "Updated" }),
-            Encoding.UTF8,
-            "application/json")
+        Content = JsonContent.Create(new { description = "Updated" })
     };
     var patchResponse = await alice.SendAsync(patchReq);
     Assert.Equal(HttpStatusCode.NoContent, patchResponse.StatusCode);
@@ -261,10 +257,7 @@ public class DeckControllerTests : IClassFixture<CustomWebApplicationFactory>
                 HttpMethod.Patch,
                 $"/api/deck/{TestDataSeeder.AliceMagicDeckId}/cards/{TestDataSeeder.ExtraMagicPrintingId}")
             {
-                Content = new StringContent(
-                    JsonSerializer.Serialize(new { quantityIdea = 4 }),
-                    Encoding.UTF8,
-                    "application/json")
+                Content = JsonContent.Create(new { quantityIdea = 4 })
             };
             var patchResponse = await client.SendAsync(patchReq);
             Assert.Equal(HttpStatusCode.NoContent, patchResponse.StatusCode);
@@ -294,10 +287,7 @@ public class DeckControllerTests : IClassFixture<CustomWebApplicationFactory>
                 HttpMethod.Patch,
                 $"/api/deck/{TestDataSeeder.AliceEmptyDeckId}")
             {
-                Content = new StringContent(
-                    JsonSerializer.Serialize(new { name = "Alice Aggro" }),
-                    Encoding.UTF8,
-                    "application/json")
+                Content = JsonContent.Create(new { name = "Alice Aggro" })
             };
 
             var response = await client.SendAsync(patchReq);

--- a/api.Tests/ImportExportControllerTests.cs
+++ b/api.Tests/ImportExportControllerTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
+using System.Net.Http.Json;
 using System.Text.Json;
 using api.Data;
 using api.Tests.Fixtures;
@@ -71,9 +71,10 @@ public class ImportExportControllerTests : IClassFixture<CustomWebApplicationFac
             await db.SaveChangesAsync();
         }
 
+        using var replaceDoc = JsonDocument.Parse(exportJson);
         var importResponse = await client.PostAsync(
             "/api/import/json?mode=replace",
-            new StringContent(exportJson, Encoding.UTF8, "application/json"));
+            JsonContent.Create(replaceDoc.RootElement.Clone()));
         importResponse.EnsureSuccessStatusCode();
 
         using (var scope = _factory.Services.CreateScope())
@@ -188,9 +189,10 @@ public class ImportExportControllerTests : IClassFixture<CustomWebApplicationFac
             await db.SaveChangesAsync();
         }
 
+        using var mergeDoc = JsonDocument.Parse(exportJson);
         var importResponse = await client.PostAsync(
             "/api/import/json?mode=merge",
-            new StringContent(exportJson, Encoding.UTF8, "application/json"));
+            JsonContent.Create(mergeDoc.RootElement.Clone()));
         importResponse.EnsureSuccessStatusCode();
 
         using (var scope = _factory.Services.CreateScope())


### PR DESCRIPTION
## Summary
- replace manual `StringContent` creation in API tests with `JsonContent.Create`
- add the necessary JSON HTTP namespace imports and remove unused `using` directives
- post import/export payloads as JSON content using parsed documents

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbe1b726d0832f8df6ad7a8a173bbe