### PR TITLE
Refactor tests to use primary constructors

### DIFF
--- a/api.Tests/ImporterTests.cs
+++ b/api.Tests/ImporterTests.cs
@@ -16,7 +16,7 @@ using api.Tests.Helpers;
 
 namespace api.Tests;
 
-public class ImporterTests : IClassFixture<CustomWebApplicationFactory>
+public class ImporterTests(CustomWebApplicationFactory factory) : IClassFixture<CustomWebApplicationFactory>
 {
     private static readonly MethodInfo UpsertMethod = typeof(ScryfallImporter)
         .GetMethod("UpsertCardAndPrintingAsync", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -34,16 +34,12 @@ public class ImporterTests : IClassFixture<CustomWebApplicationFactory>
         .GetNestedType("ScryImages", BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("Missing ScryImages type.");
 
-    private readonly CustomWebApplicationFactory _factory;
-
-    public ImporterTests(CustomWebApplicationFactory factory) => _factory = factory;
-
     [Fact]
     public async Task ScryfallImporter_Upsert_CreatesAndUpdatesEntitiesCorrectly()
     {
-        await _factory.ResetDatabaseAsync();
+        await factory.ResetDatabaseAsync();
 
-        using var scope = _factory.Services.CreateScope();
+        using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
         using var httpFactory = new StubHttpClientFactory();


### PR DESCRIPTION
## Summary
- update controller and importer tests to use C# 12 primary constructors instead of backing fields
- reuse the injected factory parameter directly and share static JsonSerializerOptions helpers
- simplify helper return values by leveraging collection expressions

## Testing
- not run (dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc05e91098832f969c9f683d22874e