### PR TITLE
Add API client, user provider, and cards page

### DIFF
--- a/client-vite/src/context/UserProvider.tsx
+++ b/client-vite/src/context/UserProvider.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useMemo, useState } from 'react';
+import { setApiUserId } from '@/lib/api';
+
+type Ctx = { userId: number; setUserId: (id: number) => void };
+const UserCtx = createContext<Ctx | undefined>(undefined);
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+  const [userId, setUserIdState] = useState<number>(() => {
+    const saved = localStorage.getItem('userId');
+    return saved ? Number(saved) : 1;
+  });
+
+  setApiUserId(userId);
+
+  const setUserId = (id: number) => {
+    localStorage.setItem('userId', String(id));
+    setUserIdState(id);
+    setApiUserId(id);
+  };
+
+  const value = useMemo(() => ({ userId, setUserId }), [userId]);
+  return <UserCtx.Provider value={value}>{children}</UserCtx.Provider>;
+}
+
+export const useUser = () => {
+  const ctx = useContext(UserCtx);
+  if (!ctx) throw new Error('useUser must be used within UserProvider');
+  return ctx;
+};

--- a/client-vite/src/lib/api.ts
+++ b/client-vite/src/lib/api.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+let currentUserId: number = 1; // default; will be updated by UserProvider
+
+export const setApiUserId = (id: number) => {
+  currentUserId = id;
+};
+
+export const api = axios.create({
+  baseURL: '/api',
+});
+
+api.interceptors.request.use((config) => {
+  config.headers = config.headers ?? {};
+  (config.headers as Record<string, string>)['X-User-Id'] = String(currentUserId);
+  return config;
+});

--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+type CardDto = { id: number; game: string; name: string };
+
+export default function CardsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['cards'],
+    queryFn: async () => {
+      const res = await api.get<CardDto[]>('/card');
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading cards</div>;
+
+  return (
+    <ul className="p-4 list-disc">
+      {data?.map((c) => (
+        <li key={c.id}>{c.game} — {c.name}</li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Axios API helper that injects the current user id header
- provide a user context that syncs the selected user id with local storage
- implement a cards page that fetches and renders cards from the API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd80bd5b10832f8600175ec67a3cac