### PR TITLE
Add navigation shell and shared route paths

### DIFF
--- a/client-vite/src/components/AppShell.tsx
+++ b/client-vite/src/components/AppShell.tsx
@@ -1,0 +1,31 @@
+import { Link, NavLink, Outlet } from 'react-router-dom';
+import { paths } from '@/routes/paths';
+
+const linkCls = ({ isActive }: { isActive: boolean }) =>
+  `px-3 py-2 rounded-md text-sm font-medium ${isActive ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white'}`;
+
+export default function AppShell() {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <header className="bg-gray-800">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-between">
+            <Link to={paths.cards} className="text-white font-semibold">TCG Tracker</Link>
+            <nav className="flex gap-1">
+              <NavLink to={paths.cards} className={linkCls}>Cards</NavLink>
+              <NavLink to={paths.collection} className={linkCls}>Collection</NavLink>
+              <NavLink to={paths.wishlist} className={linkCls}>Wishlist</NavLink>
+              <NavLink to={paths.decks} className={linkCls}>Decks</NavLink>
+              <NavLink to={paths.value} className={linkCls}>Value</NavLink>
+              <NavLink to={paths.users} className={linkCls}>Users</NavLink>
+              <NavLink to={paths.adminImport} className={linkCls}>Admin · Import</NavLink>
+            </nav>
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/client-vite/src/pages/NotFoundPage.tsx
+++ b/client-vite/src/pages/NotFoundPage.tsx
@@ -1,0 +1,8 @@
+export default function NotFoundPage() {
+  return (
+    <div className="text-center py-24">
+      <h1 className="text-3xl font-bold">404</h1>
+      <p className="text-gray-600">Page not found.</p>
+    </div>
+  );
+}

--- a/client-vite/src/routes/paths.ts
+++ b/client-vite/src/routes/paths.ts
@@ -1,0 +1,11 @@
+export const paths = {
+  cards: '/cards',
+  collection: '/collection',
+  wishlist: '/wishlist',
+  decks: '/decks',
+  adminImport: '/admin/import',
+  users: '/users',
+  value: '/value',
+} as const;
+
+export type AppPath = (typeof paths)[keyof typeof paths];


### PR DESCRIPTION
## Summary
- add shared route path constants for primary app sections
- create reusable application shell with navigation header
- add simple not found page for unmatched routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6d77ac68832f9e50a6bb590b8361