### PR TITLE
Add react-query pages for collection and admin views

### DIFF
--- a/client-vite/src/pages/AdminImportPage.tsx
+++ b/client-vite/src/pages/AdminImportPage.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+type ImportSourceDto = { source: string; description: string };
+type Paged<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export default function AdminImportPage() {
+  const { data, isLoading, error } = useQuery<Paged<ImportSourceDto>>({
+    queryKey: ['admin-import'],
+    queryFn: async () => {
+      const res = await api.get<Paged<ImportSourceDto>>('/admin/import');
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading import sources</div>;
+  if (!data || data.items.length === 0) return <div className="p-4">No import sources found</div>;
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 text-sm text-gray-500">
+        Showing {data.items.length} of {data.total}
+      </div>
+      <ul className="list-disc pl-6">
+        {data.items.map(source => (
+          <li key={source.source}>
+            {source.source} — {source.description}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/client-vite/src/pages/CollectionPage.tsx
+++ b/client-vite/src/pages/CollectionPage.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { useUser } from '@/context/UserProvider';
+import { api } from '@/lib/api';
+
+type CollectionItemDto = { id: number; game: string; name: string; quantity: number };
+type Paged<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export default function CollectionPage() {
+  const { userId } = useUser();
+  const { data, isLoading, error } = useQuery<Paged<CollectionItemDto>>({
+    queryKey: ['collection', userId],
+    queryFn: async () => {
+      const res = await api.get<Paged<CollectionItemDto>>(`/user/${userId}/collection`);
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading collection</div>;
+  if (!data || data.items.length === 0) return <div className="p-4">No collection items found</div>;
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 text-sm text-gray-500">
+        Showing {data.items.length} of {data.total}
+      </div>
+      <ul className="list-disc pl-6">
+        {data.items.map(item => (
+          <li key={item.id}>
+            {item.game} — {item.name} × {item.quantity}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/client-vite/src/pages/DecksPage.tsx
+++ b/client-vite/src/pages/DecksPage.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { useUser } from '@/context/UserProvider';
+import { api } from '@/lib/api';
+
+type DeckDto = { id: number; game: string; name: string; description?: string };
+type Paged<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export default function DecksPage() {
+  const { userId } = useUser();
+  const { data, isLoading, error } = useQuery<Paged<DeckDto>>({
+    queryKey: ['decks', userId],
+    queryFn: async () => {
+      const res = await api.get<Paged<DeckDto>>(`/user/${userId}/deck`);
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading decks</div>;
+  if (!data || data.items.length === 0) return <div className="p-4">No decks found</div>;
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 text-sm text-gray-500">
+        Showing {data.items.length} of {data.total}
+      </div>
+      <ul className="list-disc pl-6">
+        {data.items.map(deck => (
+          <li key={deck.id}>
+            {deck.game} — {deck.name}
+            {deck.description ? ` (${deck.description})` : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/client-vite/src/pages/UsersPage.tsx
+++ b/client-vite/src/pages/UsersPage.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+type UserDto = { id: number; name: string; role: string };
+type Paged<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export default function UsersPage() {
+  const { data, isLoading, error } = useQuery<Paged<UserDto>>({
+    queryKey: ['users'],
+    queryFn: async () => {
+      const res = await api.get<Paged<UserDto>>('/user');
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading users</div>;
+  if (!data || data.items.length === 0) return <div className="p-4">No users found</div>;
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 text-sm text-gray-500">
+        Showing {data.items.length} of {data.total}
+      </div>
+      <ul className="list-disc pl-6">
+        {data.items.map(user => (
+          <li key={user.id}>
+            {user.name} — {user.role}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/client-vite/src/pages/ValueHubPage.tsx
+++ b/client-vite/src/pages/ValueHubPage.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { useUser } from '@/context/UserProvider';
+import { api } from '@/lib/api';
+
+type ValuePointDto = { asOfUtc: string; priceCents: number };
+type ValueSummaryDto = { latestCents: number; points: ValuePointDto[] };
+
+export default function ValueHubPage() {
+  const { userId } = useUser();
+  const { data, isLoading, error } = useQuery<ValueSummaryDto>({
+    queryKey: ['value', userId],
+    queryFn: async () => {
+      const res = await api.get<ValueSummaryDto>(
+        `/api/value/collection/summary?userId=${userId}`,
+      );
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading value summary</div>;
+  if (!data) return <div className="p-4">No value data found</div>;
+
+  const formattedTotal = (data.latestCents / 100).toLocaleString(undefined, {
+    style: 'currency',
+    currency: 'USD',
+  });
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-2 text-xl font-semibold">Collection Value</h1>
+      <p>Latest total: {formattedTotal}</p>
+      <div className="mt-4 text-sm text-gray-500">History points: {data.points.length}</div>
+    </div>
+  );
+}
+

--- a/client-vite/src/pages/WishlistPage.tsx
+++ b/client-vite/src/pages/WishlistPage.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { useUser } from '@/context/UserProvider';
+import { api } from '@/lib/api';
+
+type WishlistItemDto = { id: number; game: string; name: string; desired: number };
+type Paged<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export default function WishlistPage() {
+  const { userId } = useUser();
+  const { data, isLoading, error } = useQuery<Paged<WishlistItemDto>>({
+    queryKey: ['wishlist', userId],
+    queryFn: async () => {
+      const res = await api.get<Paged<WishlistItemDto>>(`/user/${userId}/wishlist`);
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading wishlist</div>;
+  if (!data || data.items.length === 0) return <div className="p-4">No wishlist items found</div>;
+
+  return (
+    <div className="p-4">
+      <div className="mb-2 text-sm text-gray-500">
+        Showing {data.items.length} of {data.total}
+      </div>
+      <ul className="list-disc pl-6">
+        {data.items.map(item => (
+          <li key={item.id}>
+            {item.game} — {item.name} (want {item.desired})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add collection and wishlist pages mirroring CardsPage patterns
- introduce decks and admin import views using shared paged dto handling
- provide users and value hub pages with react-query data fetching

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6f1be4bc832fa6cdba8fbbd9663d