### PR TITLE
Add importer metadata endpoint and user list alias

### DIFF
--- a/api/Features/Admin/AdminImportController.cs
+++ b/api/Features/Admin/AdminImportController.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using api.Importing;
+
+namespace api.Features.Admin;
+
+[ApiController]
+[Route("api/admin/import")]
+public class AdminImportController : ControllerBase
+{
+    private readonly IEnumerable<ISourceImporter> _importers;
+
+    public AdminImportController(IEnumerable<ISourceImporter> importers)
+    {
+        _importers = importers;
+    }
+
+    public record ImportSourceDto(string Key, string Name, IEnumerable<string> Games);
+
+    [HttpGet("sources")]
+    public ActionResult<IEnumerable<ImportSourceDto>> GetSources()
+        => Ok(_importers.Select(i => new ImportSourceDto(i.Key, i.DisplayName, i.SupportedGames)));
+}

--- a/api/Features/Users/UsersController.cs
+++ b/api/Features/Users/UsersController.cs
@@ -213,8 +213,12 @@ public class UsersController : ControllerBase
 
     // Admin: GET /api/users
     [HttpGet("/api/users")]
-    public async Task<IActionResult> ListUsers([FromQuery] string? name = null, [FromQuery] string? displayName = null, [FromQuery] bool? isAdmin = null)
-        => await ListUsersCore(name, displayName, isAdmin);
+    public Task<IActionResult> ListUsers([FromQuery] string? name = null, [FromQuery] string? displayName = null, [FromQuery] bool? isAdmin = null)
+        => ListUsersCore(name, displayName, isAdmin);
+
+    [HttpGet("/api/user")]
+    public Task<IActionResult> ListUsersAlias([FromQuery] string? name = null, [FromQuery] string? displayName = null, [FromQuery] bool? isAdmin = null)
+        => ListUsersCore(name, displayName, isAdmin);
 
     // Admin: PUT /api/users/{userId}/admin?value=true|false
     [HttpPut("/api/users/{targetUserId:int}/admin")]

--- a/api/Importing/DiceMastersDbImporter.cs
+++ b/api/Importing/DiceMastersDbImporter.cs
@@ -12,6 +12,8 @@ namespace api.Importing;
 public sealed class DiceMastersDbImporter : ISourceImporter
 {
     public string Key => "dicemasters";
+    public string DisplayName => "DiceMastersDB";
+    public IEnumerable<string> SupportedGames => new[] { GameName };
 
     private const string GameName = "Dice Masters";
     private readonly AppDbContext _db;

--- a/api/Importing/DummyImporter.cs
+++ b/api/Importing/DummyImporter.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using api.Data;
 
 namespace api.Importing;
@@ -7,6 +9,8 @@ public sealed class DummyImporter : ISourceImporter
     private readonly AppDbContext _db;
     public DummyImporter(AppDbContext db) => _db = db;
     public string Key => "dummy";
+    public string DisplayName => "Dummy";
+    public IEnumerable<string> SupportedGames => Array.Empty<string>();
 
     public Task<ImportSummary> ImportFromRemoteAsync(ImportOptions options, CancellationToken ct = default)
         => ImportFromFileAsync(Stream.Null, options, ct);

--- a/api/Importing/FabDbImporter.cs
+++ b/api/Importing/FabDbImporter.cs
@@ -10,6 +10,8 @@ namespace api.Importing;
 public sealed class FabDbImporter : ISourceImporter
 {
     public string Key => "fabdb";
+    public string DisplayName => "FAB DB";
+    public IEnumerable<string> SupportedGames => new[] { "Flesh and Blood" };
 
     private readonly AppDbContext _db;
     private readonly HttpClient _http;

--- a/api/Importing/GuardiansLocalImporter.cs
+++ b/api/Importing/GuardiansLocalImporter.cs
@@ -13,6 +13,8 @@ namespace api.Importing;
 public sealed class GuardiansLocalImporter : ISourceImporter
 {
     public string Key => "guardians";
+    public string DisplayName => "Guardians Local";
+    public IEnumerable<string> SupportedGames => new[] { "Guardians CCG" };
     private readonly AppDbContext _db;
     private static readonly JsonSerializerOptions J = new(JsonSerializerDefaults.Web)
     {

--- a/api/Importing/ISourceImporter.cs
+++ b/api/Importing/ISourceImporter.cs
@@ -1,9 +1,17 @@
+using System.Collections.Generic;
+
 namespace api.Importing;
 
 public interface ISourceImporter
 {
     /// Unique key. Example: "scryfall", "swccgdb", "lorcanajson", "swu".
     string Key { get; }
+
+    /// Human-readable source name (e.g., "Scryfall").
+    string DisplayName { get; }
+
+    /// Games this importer can populate (e.g., ["Magic"], ["Star Wars CCG"], ...).
+    IEnumerable<string> SupportedGames { get; }
 
     /// Pulls from a remote API this importer knows how to query.
     Task<ImportSummary> ImportFromRemoteAsync(ImportOptions options, CancellationToken ct = default);

--- a/api/Importing/LorcanaJsonImporter.cs
+++ b/api/Importing/LorcanaJsonImporter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using api.Data;
 using api.Models;
@@ -8,6 +9,8 @@ namespace api.Importing;
 public sealed class LorcanaJsonImporter : ISourceImporter
 {
     public string Key => "lorcanajson";
+    public string DisplayName => "Lorcana JSON";
+    public IEnumerable<string> SupportedGames => new[] { "Disney Lorcana" };
 
     private readonly AppDbContext _db;
     private readonly HttpClient _http;

--- a/api/Importing/PokemonTcgImporter.cs
+++ b/api/Importing/PokemonTcgImporter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -10,6 +11,8 @@ namespace api.Importing;
 public sealed class PokemonTcgImporter : ISourceImporter
 {
     public string Key => "pokemon";
+    public string DisplayName => "Pokémon TCG";
+    public IEnumerable<string> SupportedGames => new[] { "Pokemon" };
     private readonly AppDbContext _db;
     private readonly HttpClient _http;
     private static readonly JsonSerializerOptions J = new(JsonSerializerDefaults.Web) { PropertyNameCaseInsensitive = true };

--- a/api/Importing/ScryfallImporter.cs
+++ b/api/Importing/ScryfallImporter.cs
@@ -22,6 +22,8 @@ public sealed class ScryfallImporter : ISourceImporter
     }
 
     public string Key => "scryfall";
+    public string DisplayName => "Scryfall";
+    public IEnumerable<string> SupportedGames => new[] { "Magic" };
 
     public Task<ImportSummary> ImportFromRemoteAsync(ImportOptions options, CancellationToken ct = default)
     {

--- a/api/Importing/SwccgdbImporter.cs
+++ b/api/Importing/SwccgdbImporter.cs
@@ -27,6 +27,8 @@ public sealed class SwccgdbImporter : ISourceImporter
     }
 
     public string Key => "swccgdb";
+    public string DisplayName => "SWCCG DB";
+    public IEnumerable<string> SupportedGames => new[] { "Star Wars CCG" };
 
     public Task<ImportSummary> ImportFromRemoteAsync(ImportOptions options, CancellationToken ct = default)
     {

--- a/api/Importing/SwuDbImporter.cs
+++ b/api/Importing/SwuDbImporter.cs
@@ -10,6 +10,8 @@ namespace api.Importing;
 public sealed class SwuDbImporter : ISourceImporter
 {
     public string Key => "swu";
+    public string DisplayName => "SWU DB";
+    public IEnumerable<string> SupportedGames => new[] { "Star Wars Unlimited" };
     private readonly AppDbContext _db;
     private readonly HttpClient _http;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)

--- a/api/Importing/TransformersFmImporter.cs
+++ b/api/Importing/TransformersFmImporter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using api.Data;
 using api.Models;
@@ -8,6 +9,8 @@ namespace api.Importing;
 public sealed class TransformersFmImporter : ISourceImporter
 {
     public string Key => "tftcg";
+    public string DisplayName => "FortressMaximus";
+    public IEnumerable<string> SupportedGames => new[] { "Transformers TCG" };
     private readonly AppDbContext _db;
     private readonly HttpClient _http;
     private static readonly JsonSerializerOptions J = new(JsonSerializerDefaults.Web)

--- a/client-vite/src/pages/AdminImportPage.tsx
+++ b/client-vite/src/pages/AdminImportPage.tsx
@@ -1,42 +1,28 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
-type ImportSourceDto = { source: string; description: string };
-type Paged<T> = {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-};
+type ImportSourceDto = { key: string; name: string; games: string[] };
 
 export default function AdminImportPage() {
-  const { data, isLoading, error } = useQuery<Paged<ImportSourceDto>>({
-  queryKey: ['admin-import'],
-  queryFn: async () => {
-    const res = await api.get<ImportSourceDto[] | Paged<ImportSourceDto>>('/admin/import');
-    const d: ImportSourceDto[] | Paged<ImportSourceDto> = res.data;
-
-    if (Array.isArray(d)) {
-      return { items: d, total: d.length, page: 1, pageSize: d.length };
-    }
-
-    return d;
-  },
-});
+  const { data, isLoading, isError } = useQuery<ImportSourceDto[]>({
+    queryKey: ['import-sources'],
+    queryFn: () => api.get<ImportSourceDto[]>('/admin/import/sources').then(r => r.data),
+  });
 
   if (isLoading) return <div className="p-4">Loading…</div>;
-  if (error) return <div className="p-4 text-red-500">Error loading import sources</div>;
-  if (!data || data.items.length === 0) return <div className="p-4">No import sources found</div>;
+  if (isError) return <div className="p-4 text-red-500">Error loading import sources</div>;
+  if (!data || data.length === 0) return <div className="p-4">No import sources found</div>;
 
   return (
     <div className="p-4">
       <div className="mb-2 text-sm text-gray-500">
-        Showing {data.items.length} of {data.total}
+        Showing {data.length} import source{data.length === 1 ? '' : 's'}
       </div>
       <ul className="list-disc pl-6">
-        {data.items.map(source => (
-          <li key={source.source}>
-            {source.source} — {source.description}
+        {data.map(source => (
+          <li key={source.key}>
+            {source.name}
+            {source.games.length > 0 ? ` — ${source.games.join(', ')}` : ''}
           </li>
         ))}
       </ul>

--- a/client-vite/src/pages/UsersPage.tsx
+++ b/client-vite/src/pages/UsersPage.tsx
@@ -11,22 +11,24 @@ type Paged<T> = {
 };
 
 export default function UsersPage() {
-  const { data, isLoading, error } = useQuery<Paged<UserDto>>({
+  const { data, isLoading, isError } = useQuery<Paged<UserDto>>({
     queryKey: ['users'],
     queryFn: async () => {
-      const res = await api.get<UserDto[] | Paged<UserDto>>('/user');
-      const d: UserDto[] | Paged<UserDto> = res.data;
+      const res = await api.get<
+        Array<{ id: number; username: string; displayName: string; isAdmin: boolean }>
+      >('/users');
+      const users = res.data.map(user => ({
+        id: user.id,
+        name: user.displayName || user.username,
+        role: user.isAdmin ? 'Admin' : 'User',
+      }));
 
-      if (Array.isArray(d)) {
-        return { items: d, total: d.length, page: 1, pageSize: d.length };
-      }
-
-      return d;
+      return { items: users, total: users.length, page: 1, pageSize: users.length };
     },
   });
 
   if (isLoading) return <div className="p-4">Loading…</div>;
-  if (error) return <div className="p-4 text-red-500">Error loading users</div>;
+  if (isError) return <div className="p-4 text-red-500">Error loading users</div>;
   if (!data || data.items.length === 0) return <div className="p-4">No users found</div>;
 
   return (


### PR DESCRIPTION
## Summary
- add an admin import controller endpoint that exposes the available import sources
- extend the importer interface with display metadata and update each importer to provide it
- expose a /api/user alias and update the admin pages to consume the corrected endpoints

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de8d32eca4832f9b7946e7c9380fbd