### PR TITLE
Remove redundant react-router-dom type dependency

### DIFF
--- a/client-vite/package-lock.json
+++ b/client-vite/package-lock.json
@@ -20,7 +20,6 @@
         "@types/node": "^24.6.2",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
-        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react-swc": "^4.1.0",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.36.0",
@@ -1699,18 +1698,6 @@
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/client-vite/package.json
+++ b/client-vite/package.json
@@ -22,7 +22,6 @@
     "@types/node": "^24.6.2",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react-swc": "^4.1.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",


### PR DESCRIPTION
## Summary
- remove the @types/react-router-dom dev dependency now that react-router-dom v7 bundles types
- keep react-router-dom pinned to the existing 7.x release line without modifying other packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de96d5e4c8832fa6643a59f385b75d