### PR TITLE
Handle array responses in collection and deck pages

### DIFF
--- a/client-vite/src/pages/CollectionPage.tsx
+++ b/client-vite/src/pages/CollectionPage.tsx
@@ -16,32 +16,25 @@ type CollectionItemDto = {
   style: string;
   imageUrl: string | null;
 };
-type Paged<T> = {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-};
-
 export default function CollectionPage() {
   const { userId } = useUser();
-  const { data, isLoading, error } = useQuery<Paged<CollectionItemDto>>({
+  const { data: items = [], isLoading, error } = useQuery<CollectionItemDto[]>({
     queryKey: ['collection', userId],
     queryFn: async () => {
-      const res = await api.get<Paged<CollectionItemDto>>(`/user/${userId}/collection`);
+      const res = await api.get<CollectionItemDto[]>(`/user/${userId}/collection`);
       return res.data;
     },
   });
 
   if (isLoading) return <div className="p-4">Loading…</div>;
   if (error) return <div className="p-4 text-red-500">Error loading collection</div>;
-  if (!data || data.items.length === 0) return <div className="p-4">No collection items found</div>;
+  if (items.length === 0) return <div className="p-4">No collection items found</div>;
 
   return (
     <div className="p-4">
-      <div className="mb-2 text-sm text-gray-500">Showing {data.items.length} of {data.total}</div>
+      <div className="mb-2 text-sm text-gray-500">Showing {items.length} items</div>
       <ul className="list-disc pl-6">
-        {data.items.map(i => (
+        {items.map(i => (
           <li key={i.cardPrintingId}>
             {i.game} — {i.cardName} · owned {i.quantityOwned} · want {i.quantityWanted} · proxy {i.quantityProxyOwned}
           </li>

--- a/client-vite/src/pages/DecksPage.tsx
+++ b/client-vite/src/pages/DecksPage.tsx
@@ -11,32 +11,25 @@ type DeckDto = {
   createdUtc: string;
   updatedUtc: string | null;
 };
-type Paged<T> = {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-};
-
 export default function DecksPage() {
   const { userId } = useUser();
-  const { data, isLoading, error } = useQuery<Paged<DeckDto>>({
+  const { data: decks = [], isLoading, error } = useQuery<DeckDto[]>({
     queryKey: ['decks', userId],
     queryFn: async () => {
-      const res = await api.get<Paged<DeckDto>>(`/user/${userId}/deck`);
+      const res = await api.get<DeckDto[]>(`/user/${userId}/deck`);
       return res.data;
     },
   });
 
   if (isLoading) return <div className="p-4">Loading…</div>;
   if (error) return <div className="p-4 text-red-500">Error loading decks</div>;
-  if (!data || data.items.length === 0) return <div className="p-4">No decks found</div>;
+  if (decks.length === 0) return <div className="p-4">No decks found</div>;
 
   return (
     <div className="p-4">
-      <div className="mb-2 text-sm text-gray-500">Showing {data.items.length} of {data.total}</div>
+      <div className="mb-2 text-sm text-gray-500">Showing {decks.length} decks</div>
       <ul className="list-disc pl-6">
-        {data.items.map(d => (
+        {decks.map(d => (
           <li key={d.id}>
             {d.game} — {d.name}{d.description ? ` (${d.description})` : ''} · {new Date(d.createdUtc).toLocaleDateString()}
           </li>

--- a/client-vite/src/pages/WishlistPage.tsx
+++ b/client-vite/src/pages/WishlistPage.tsx
@@ -14,32 +14,25 @@ type WishlistItemDto = {
   style: string;
   imageUrl: string | null;
 };
-type Paged<T> = {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-};
-
 export default function WishlistPage() {
   const { userId } = useUser();
-  const { data, isLoading, error } = useQuery<Paged<WishlistItemDto>>({
+  const { data: items = [], isLoading, error } = useQuery<WishlistItemDto[]>({
     queryKey: ['wishlist', userId],
     queryFn: async () => {
-      const res = await api.get<Paged<WishlistItemDto>>(`/user/${userId}/wishlist`);
+      const res = await api.get<WishlistItemDto[]>(`/user/${userId}/wishlist`);
       return res.data;
     },
   });
 
   if (isLoading) return <div className="p-4">Loading…</div>;
   if (error) return <div className="p-4 text-red-500">Error loading wishlist</div>;
-  if (!data || data.items.length === 0) return <div className="p-4">No wishlist items found</div>;
+  if (items.length === 0) return <div className="p-4">No wishlist items found</div>;
 
   return (
     <div className="p-4">
-      <div className="mb-2 text-sm text-gray-500">Showing {data.items.length} of {data.total}</div>
+      <div className="mb-2 text-sm text-gray-500">Showing {items.length} items</div>
       <ul className="list-disc pl-6">
-        {data.items.map(i => (
+        {items.map(i => (
           <li key={i.cardPrintingId}>
             {i.game} — {i.cardName} · want {i.quantityWanted}
           </li>


### PR DESCRIPTION
## Summary
- update collection, wishlist, and decks pages to fetch array responses instead of paged results
- adjust empty-state handling and list rendering to use the returned arrays directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9e57b4a4832f88097aefef03fa71