### PR TITLE
Fix AdminImportController attribute placement

### DIFF
--- a/api/Controllers/AdminImportController.cs
+++ b/api/Controllers/AdminImportController.cs
@@ -8,11 +8,11 @@ using System.Linq;
 
 namespace api.Controllers;
 
+public sealed record ImportSourceResponse(string Key, string Name, IReadOnlyList<string> Games);
+
 [ApiController]
 [Route("api/admin/import")]
 [AdminGuard]
-public sealed record ImportSourceResponse(string Key, string Name, IReadOnlyList<string> Games);
-
 public sealed class AdminImportController : ControllerBase
 {
     private readonly ImporterRegistry _registry;


### PR DESCRIPTION
## Summary
- move ImportSourceResponse record above the controller attributes so the filters apply to the controller

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dea50a39d8832f900db8f9a7944a05