### PR TITLE
Fix importer registry lifetime

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -40,7 +40,7 @@ builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.FabDbImp
 builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.GuardiansLocalImporter>();
 builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.DiceMastersDbImporter>();
 builder.Services.AddScoped<api.Importing.ISourceImporter, api.Importing.TransformersFmImporter>();
-builder.Services.AddSingleton<api.Importing.ImporterRegistry>();
+builder.Services.AddScoped<api.Importing.ImporterRegistry>();
 
 // Explicit HTTPS port for redirects
 builder.Services.AddHttpsRedirection(o => o.HttpsPort = 7226);


### PR DESCRIPTION
## Summary
- register ImporterRegistry with scoped lifetime to align with scoped importers

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea5be550c832fb8caf18b5c5f5aa7