### PR TITLE
Update ValueHubPage to use collection summary DTO

### DIFF
--- a/client-vite/src/pages/ValueHubPage.tsx
+++ b/client-vite/src/pages/ValueHubPage.tsx
@@ -2,30 +2,18 @@ import { useQuery } from '@tanstack/react-query';
 import { useUser } from '@/context/useUser';
 import { api } from '@/lib/api';
 
-type ValuePointDto = { asOfUtc: string; priceCents: number };
-type ValueSummaryDto = { latestCents: number; points: ValuePointDto[] };
+type GameSliceDto = { game: string; cents: number };
+type CollectionSummaryDto = { totalCents: number; byGame: GameSliceDto[] };
 
 export default function ValueHubPage() {
   const { userId } = useUser();
 
-  const { data, isLoading, error } = useQuery<ValueSummaryDto>({
+  const { data, isLoading, error } = useQuery<CollectionSummaryDto>({
     queryKey: ['value', userId],
     queryFn: async () => {
       // Call backend
-      const res = await api.get<ValueSummaryDto | ValuePointDto[]>(
-        `/value/collection/summary?userId=${userId}`
-      );
-      const d: ValueSummaryDto | ValuePointDto[] = res.data;
-
-      if (Array.isArray(d)) {
-        // If backend sent an array of points, wrap it in ValueSummaryDto
-        const points: ValuePointDto[] = d;
-        const latestCents = points.length ? points[points.length - 1].priceCents : 0;
-        return { latestCents, points };
-      }
-
-      // Normal case: already a ValueSummaryDto
-      return d;
+      const res = await api.get<CollectionSummaryDto>('/value/collection/summary');
+      return res.data;
     },
   });
 
@@ -33,7 +21,7 @@ export default function ValueHubPage() {
   if (error) return <div className="p-4 text-red-500">Error loading value summary</div>;
   if (!data) return <div className="p-4">No value data found</div>;
 
-  const formattedTotal = (data.latestCents / 100).toLocaleString(undefined, {
+  const formattedTotal = (data.totalCents / 100).toLocaleString(undefined, {
     style: 'currency',
     currency: 'USD',
   });
@@ -42,8 +30,27 @@ export default function ValueHubPage() {
     <div className="p-4">
       <h1 className="mb-2 text-xl font-semibold">Collection Value</h1>
       <p>Latest total: {formattedTotal}</p>
-      <div className="mt-4 text-sm text-gray-500">
-        History points: {data.points.length}
+      <div className="mt-4">
+        <h2 className="mb-2 text-lg font-medium">By Game</h2>
+        {data.byGame.length === 0 ? (
+          <p className="text-sm text-gray-500">No game breakdown available.</p>
+        ) : (
+          <ul className="space-y-1 text-sm text-gray-700">
+            {data.byGame.map((slice) => {
+              const formattedSliceTotal = (slice.cents / 100).toLocaleString(undefined, {
+                style: 'currency',
+                currency: 'USD',
+              });
+
+              return (
+                <li key={slice.game} className="flex justify-between">
+                  <span>{slice.game}</span>
+                  <span>{formattedSliceTotal}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- align ValueHubPage DTO types with the collection summary API response
- adjust the React Query call to request the summary endpoint without per-user params
- render the total value and per-game breakdown using formatted currency values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea6f342c4832fa2e02a80121d03a8