### PR TITLE
Fix Card DTO casing on CardsPage

### DIFF
--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useUser } from '@/context/useUser';
 import { api } from '@/lib/api';
 
-type CardDto = { cardid: number; game: string; name: string };
+type CardDto = { cardId: number; game: string; name: string };
 type Paged<T> = {
   items: T[];
   total: number;
@@ -31,7 +31,7 @@ export default function CardsPage() {
       </div>
       <ul className="list-disc pl-6">
         {data.items.map(c => (
-          <li key={c.cardid}>{c.game} — {c.name}</li>
+          <li key={c.cardId}>{c.game} — {c.name}</li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- update the `CardDto` type on the cards page to use the camelCase `cardId`
- adjust list rendering to reference `cardId`, ensuring stable keys

## Testing
- npm run build *(fails: TS5103 invalid value for --ignoreDeprecations)*

------
https://chatgpt.com/codex/tasks/task_e_68debd0e086c832fb43d893c450c0e36