### PR TITLE
Avoid deleting collection rows when patching quantities to zero

### DIFF
--- a/api.Tests/CollectionControllerTests.cs
+++ b/api.Tests/CollectionControllerTests.cs
@@ -197,6 +197,34 @@ public class CollectionControllerTests(CustomWebApplicationFactory factory)
     }
 
     [Fact]
+    public async Task Collection_Patch_AllZero_DoesNotDeleteRow()
+    {
+        await factory.ResetDatabaseAsync();
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var patchReq = new HttpRequestMessage(
+            HttpMethod.Patch,
+            $"/api/collection/{TestDataSeeder.LightningBoltBetaPrintingId}")
+        {
+            Content = JsonContent.Create(new
+            {
+                quantityOwned = 0,
+                quantityWanted = 0,
+                quantityProxyOwned = 0
+            })
+        };
+
+        var response = await client.SendAsync(patchReq);
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var rows = await GetCollectionAsync(client, $"?cardPrintingId={TestDataSeeder.LightningBoltBetaPrintingId}");
+        var row = Assert.Single(rows);
+        Assert.Equal(0, row.QuantityOwned);
+        Assert.Equal(0, row.QuantityWanted);
+        Assert.Equal(0, row.QuantityProxyOwned);
+    }
+
+    [Fact]
     public async Task Collection_Delta_CreatesMissing_ValidatesIds()
     {
         await factory.ResetDatabaseAsync();

--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -205,11 +205,6 @@ public class CollectionsController : ControllerBase
 
         if (!touched) return NoContent();
 
-        if (IsZero(uc))
-        {
-            _db.UserCards.Remove(uc);
-        }
-
         await _db.SaveChangesAsync();
         return NoContent();
     }


### PR DESCRIPTION
## Summary
- keep user card rows when PATCH updates quantities down to zero
- add a collection controller test to ensure patching to all zeros leaves the row intact

## Testing
- dotnet test *(fails: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df4a30f8c0832f9bbaa08ed918b4fe