### PR TITLE
Fix collection test helper deserialization

### DIFF
--- a/api.Tests/CollectionControllerTests.cs
+++ b/api.Tests/CollectionControllerTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Json;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using api.Features.Collections.Dtos;
+using api.Shared;
 using api.Tests.Fixtures;
 using api.Tests.Helpers;
 using Xunit;
@@ -315,7 +316,7 @@ public class CollectionControllerTests(CustomWebApplicationFactory factory)
     {
         var response = await client.GetAsync($"/api/collection{query}");
         response.EnsureSuccessStatusCode();
-        var payload = await response.Content.ReadFromJsonAsync<List<UserCardItemResponse>>(_jsonOptions);
-        return payload ?? [];
+        var payload = await response.Content.ReadFromJsonAsync<Paged<UserCardItemResponse>>(_jsonOptions);
+        return payload?.Items?.ToList() ?? [];
     }
 }


### PR DESCRIPTION
## Summary
- update the collection test helper to deserialize the paged payload returned by the API
- pull the shared Paged<T> contract into the tests so the helper mirrors the controller response

## Testing
- dotnet test api.Tests --filter Collection *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df4d55f684832f88efe3347ff89f14