### PR TITLE
Add dev-only helpers for verifying X-User-Id header updates

### DIFF
--- a/client-vite/src/components/app/Header.tsx
+++ b/client-vite/src/components/app/Header.tsx
@@ -122,6 +122,11 @@ export default function Header() {
                 ))}
               </SelectContent>
             </Select>
+            {import.meta.env.DEV && userId != null && (
+              <span className="text-xs text-muted-foreground" aria-hidden>
+                X-User-Id={userId}
+              </span>
+            )}
           </div>
         </div>
 

--- a/client-vite/src/lib/http.ts
+++ b/client-vite/src/lib/http.ts
@@ -79,3 +79,7 @@ http.interceptors.request.use((cfg) => {
 });
 
 export default http;
+
+export function __debugGetCurrentUserId() {
+  return import.meta.env.DEV ? currentUserId : null;
+}

--- a/client-vite/src/state/UserContext.tsx
+++ b/client-vite/src/state/UserContext.tsx
@@ -27,56 +27,56 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const refreshUsers = useCallback(async () => {
-  try {
-    // 1) Try full list (works for admins or if API allows everyone)
-    const listRes = await http.get<ApiUser[]>("user");
-    const list = (listRes.data ?? []).map(mapUser);
+    try {
+      // 1) Try full list (works for admins or if API allows everyone)
+      const listRes = await http.get<ApiUser[]>("user");
+      const list = (listRes.data ?? []).map(mapUser);
 
-    if (list.length) {
-      setUsers(list);
+      if (list.length) {
+        setUsers(list);
+        if (userId == null) {
+          const first = list[0].id;
+          setUserIdState(first);
+          localStorage.setItem("userId", String(first));
+          setHttpUserId(first);
+        }
+        return;
+      }
+    } catch {
+      // ignore and try /user/me next
+    }
+
+    try {
+      // 2) Fallback: current user only
+      const meRes = await http.get<ApiUser>("user/me");
+      const me = mapUser(meRes.data);
+      setUsers([me]);
+
       if (userId == null) {
-        const first = list[0].id;
-        setUserIdState(first);
-        localStorage.setItem("userId", String(first));
-        setHttpUserId(first);
+        setUserIdState(me.id);
+        localStorage.setItem("userId", String(me.id));
+        setHttpUserId(me.id);
       }
       return;
+    } catch {
+      // ignore and fallback below
     }
-  } catch {
-    // ignore and try /user/me next
-  }
 
-  try {
-    // 2) Fallback: current user only
-    const meRes = await http.get<ApiUser>("user/me");
-    const me = mapUser(meRes.data);
-    setUsers([me]);
+    // 3) Last-resort fallback so the UI is usable
+    const fallback: UserLite[] = [{ id: 1, name: "Me", isAdmin: false }];
+    setUsers(fallback);
 
     if (userId == null) {
-      setUserIdState(me.id);
-      localStorage.setItem("userId", String(me.id));
-      setHttpUserId(me.id);
+      setUserIdState(1);
+      localStorage.setItem("userId", "1");
+      setHttpUserId(1);
     }
-    return;
-  } catch {
-    // ignore and fallback below
-  }
 
-  // 3) Last-resort fallback so the UI is usable
-  const fallback: UserLite[] = [{ id: 1, name: "Me", isAdmin: false }];
-  setUsers(fallback);
-
-  if (userId == null) {
-    setUserIdState(1);
-    localStorage.setItem("userId", "1");
-    setHttpUserId(1);
-  }
-
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.warn("[UserContext] Could not load users; using fallback");
-  }
-}, [userId]);
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn("[UserContext] Could not load users; using fallback");
+    }
+  }, [userId]);
 
 
   useEffect(() => {
@@ -89,6 +89,43 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     setHttpUserId(id);
     qc.invalidateQueries();
   };
+
+  /**
+   * Manual QA (DEV only):
+   * 1) Open DevTools → Network.
+   * 2) Change the user from the header dropdown.
+   * 3) Observe a new request (e.g., GET user/me) fired by this effect.
+   * 4) Click the request → Headers tab → Request Headers.
+   * 5) Confirm `X-User-Id: <selected id>` matches the new selection.
+   * 6) Navigate around (Cards/Collection/etc.) and confirm subsequent requests also carry the new header.
+   *
+   * NOTE: This effect and debug UI are DEV-only and safe to keep;
+   * remove them later if you prefer a cleaner console.
+   */
+  useEffect(() => {
+    if (!import.meta.env.DEV || userId == null) return;
+
+    (async () => {
+      const endpoints = ["user/me", "card"];
+      let lastError: unknown = null;
+
+      for (const endpoint of endpoints) {
+        try {
+          const res = await http.get(endpoint);
+          console.info("[X-User-Id verify]", { userId, status: res.status, endpoint });
+          return;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      console.info("[X-User-Id verify] request failed", {
+        userId,
+        error: lastError,
+        endpoints,
+      });
+    })();
+  }, [userId]);
 
   const value = useMemo(
     () => ({ userId, setUserId, users, refreshUsers }),


### PR DESCRIPTION
## Summary
- add a dev helper to inspect the active X-User-Id header and keep axios request headers in sync
- log and visualize the active user in dev along with a manual QA checklist for verifying header propagation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfec6b1a98832f8fe1d4ee98a79af7