### PR TITLE
Fix seed foreign keys and add integrity test

### DIFF
--- a/api.Tests/Fixtures/TestDataSeeder.cs
+++ b/api.Tests/Fixtures/TestDataSeeder.cs
@@ -39,7 +39,7 @@ public static class TestDataSeeder
 
         var lightningBolt = new Card
         {
-            Id = LightningBoltCardId,
+            CardId = LightningBoltCardId,
             Game = "Magic",
             Name = "Lightning Bolt",
             CardType = "Spell",
@@ -48,7 +48,7 @@ public static class TestDataSeeder
 
         var goblinGuide = new Card
         {
-            Id = GoblinGuideCardId,
+            CardId = GoblinGuideCardId,
             Game = "Magic",
             Name = "Goblin Guide",
             CardType = "Creature",
@@ -57,7 +57,7 @@ public static class TestDataSeeder
 
         var elsa = new Card
         {
-            Id = ElsaCardId,
+            CardId = ElsaCardId,
             Game = "Lorcana",
             Name = "Elsa, Ice Sculptor",
             CardType = "Character",
@@ -66,7 +66,7 @@ public static class TestDataSeeder
 
         var mickey = new Card
         {
-            Id = MickeyCardId,
+            CardId = MickeyCardId,
             Game = "Lorcana",
             Name = "Mickey, Brave Tailor",
             CardType = "Character",

--- a/api.Tests/Seed/SeedIntegrityTests.cs
+++ b/api.Tests/Seed/SeedIntegrityTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using api.Data;
+using api.Tests.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace api.Tests.Seed;
+
+public class SeedIntegrityTests(CustomWebApplicationFactory factory)
+    : IClassFixture<CustomWebApplicationFactory>
+{
+    [Fact]
+    public async Task SeededData_HasNoOrphanedForeignKeys()
+    {
+        await factory.ResetDatabaseAsync();
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var orphanedPrintings = await db.CardPrintings
+            .Where(p => !db.Cards.Any(c => c.CardId == p.CardId))
+            .ToListAsync();
+        Assert.Empty(orphanedPrintings);
+
+        var orphanedDeckCards = await db.DeckCards
+            .Where(dc => !db.Decks.Any(d => d.Id == dc.DeckId)
+                         || !db.CardPrintings.Any(p => p.Id == dc.CardPrintingId))
+            .ToListAsync();
+        Assert.Empty(orphanedDeckCards);
+    }
+}

--- a/api/Data/AppDbContext.cs
+++ b/api/Data/AppDbContext.cs
@@ -22,15 +22,20 @@ namespace api.Data
             b.Entity<Card>()
                 .HasKey(c => c.CardId);
 
+            b.Entity<CardPrinting>()
+                .HasOne(p => p.Card)
+                .WithMany(c => c.Printings)
+                .HasForeignKey(p => p.CardId)
+                .OnDelete(DeleteBehavior.Cascade);
+
             b.Entity<Deck>()
                 .HasMany(d => d.Cards)
                 .WithOne(dc => dc.Deck!)
-                .HasForeignKey(dc => dc.DeckId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .HasForeignKey(dc => dc.DeckId);
 
             b.Entity<DeckCard>()
                 .HasOne(dc => dc.CardPrinting)
-                .WithMany()
+                .WithMany(p => p.DeckCards)
                 .HasForeignKey(dc => dc.CardPrintingId)
                 .OnDelete(DeleteBehavior.Restrict);
 

--- a/api/Data/DbSeeder.cs
+++ b/api/Data/DbSeeder.cs
@@ -1,6 +1,7 @@
 ﻿using api.Data;
 using api.Models;
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace api.Data // Update to match your folder/namespace
@@ -17,7 +18,8 @@ namespace api.Data // Update to match your folder/namespace
             var user2 = new User { Username = "Grayson", DisplayName = "Astroracer", IsAdmin = true };
             var user3 = new User { Username = "Perrin", DisplayName = "DinoRoar", IsAdmin = true };
 
-            context.Users.AddRange(user1, user2);
+            context.Users.AddRange(user1, user2, user3);
+            context.SaveChanges();
 
             // Seed Cards
             var card1 = new Card { Name = "Disabling Fang Fighter", Game = "Star Wars Unlimited", CardType = "Unit" };
@@ -297,10 +299,22 @@ namespace api.Data // Update to match your folder/namespace
             context.SaveChanges(); // Save to get IDs for relationships
 
             // Seed DeckCards
-            var deck1Card1 = new DeckCard { DeckId = deck1.Id, CardPrintingId = printing1a.Id, QuantityInDeck = 2, QuantityIdea = 1, QuantityAcquire = 1, QuantityProxy = 0 };
-            var deck1Card2 = new DeckCard { DeckId = deck1.Id, CardPrintingId = printing1b.Id, QuantityInDeck = 1, QuantityIdea = 0, QuantityAcquire = 0, QuantityProxy = 0 };
-            var deck2Card1 = new DeckCard { DeckId = deck2.Id, CardPrintingId = printing2a.Id, QuantityInDeck = 3, QuantityIdea = 3, QuantityAcquire = 0, QuantityProxy = 0 };
-            var deck2Card2 = new DeckCard { DeckId = deck2.Id, CardPrintingId = printing2b.Id, QuantityInDeck = 2, QuantityIdea = 1, QuantityAcquire = 2, QuantityProxy = 0 };
+            Debug.Assert(deck1.Id != 0, "Deck 1 must have a persisted key before seeding deck cards.");
+            Debug.Assert(deck2.Id != 0, "Deck 2 must have a persisted key before seeding deck cards.");
+            Debug.Assert(printing1a.Id != 0 && printing1b.Id != 0 && printing2a.Id != 0 && printing2b.Id != 0, "Card printing keys must be generated before deck cards are added.");
+            Debug.Assert(context.Decks.Any(d => d.Id == deck1.Id), "Deck 1 could not be found in the database prior to seeding deck cards.");
+            Debug.Assert(context.Decks.Any(d => d.Id == deck2.Id), "Deck 2 could not be found in the database prior to seeding deck cards.");
+            Debug.Assert(context.CardPrintings.Any(p => p.Id == printing1a.Id), "Printing 1A is missing before deck cards are added.");
+            Debug.Assert(context.CardPrintings.Any(p => p.Id == printing1b.Id), "Printing 1B is missing before deck cards are added.");
+            Debug.Assert(context.CardPrintings.Any(p => p.Id == printing2a.Id), "Printing 2A is missing before deck cards are added.");
+            Debug.Assert(context.CardPrintings.Any(p => p.Id == printing2b.Id), "Printing 2B is missing before deck cards are added.");
+
+            Console.WriteLine($"Seeding DeckCards for Decks {deck1.Id} and {deck2.Id}.");
+
+            var deck1Card1 = new DeckCard { Deck = deck1, CardPrinting = printing1a, QuantityInDeck = 2, QuantityIdea = 1, QuantityAcquire = 1, QuantityProxy = 0 };
+            var deck1Card2 = new DeckCard { Deck = deck1, CardPrinting = printing1b, QuantityInDeck = 1, QuantityIdea = 0, QuantityAcquire = 0, QuantityProxy = 0 };
+            var deck2Card1 = new DeckCard { Deck = deck2, CardPrinting = printing2a, QuantityInDeck = 3, QuantityIdea = 3, QuantityAcquire = 0, QuantityProxy = 0 };
+            var deck2Card2 = new DeckCard { Deck = deck2, CardPrinting = printing2b, QuantityInDeck = 2, QuantityIdea = 1, QuantityAcquire = 2, QuantityProxy = 0 };
             context.DeckCards.AddRange(deck1Card1, deck1Card2, deck2Card1, deck2Card2);
             context.SaveChanges();
         }

--- a/api/Migrations/AppDbContextModelSnapshot.cs
+++ b/api/Migrations/AppDbContextModelSnapshot.cs
@@ -240,6 +240,7 @@ namespace api.Migrations
                         .IsRequired();
 
                     b.Navigation("Card");
+                    b.Navigation("DeckCards");
                 });
 
             modelBuilder.Entity("api.Models.Deck", b =>
@@ -256,7 +257,7 @@ namespace api.Migrations
             modelBuilder.Entity("api.Models.DeckCard", b =>
                 {
                     b.HasOne("api.Models.CardPrinting", "CardPrinting")
-                        .WithMany()
+                        .WithMany("DeckCards")
                         .HasForeignKey("CardPrintingId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();

--- a/api/Models/CardPrinting.cs
+++ b/api/Models/CardPrinting.cs
@@ -1,4 +1,6 @@
-﻿namespace api.Models
+﻿using System.Collections.Generic;
+
+namespace api.Models
 {
     public class CardPrinting
     {
@@ -11,5 +13,6 @@
         public required string Style { get; set; } // Standard, Foil, Hyperspace, Showcase etc..
         public string? ImageUrl { get; set; } // url to card image
         public string? DetailsJson { get; set; } // Source-specific payload
+        public ICollection<DeckCard> DeckCards { get; set; } = new List<DeckCard>();
     }
 }


### PR DESCRIPTION
## Summary
- ensure the database seeder persists users before creating dependent rows and uses tracked navigation properties for deck cards
- tighten EF Core relationship mappings for card printings and deck cards and add runtime assertions to catch orphaned records
- add a regression test that checks seeded data has valid foreign key references

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e26e86fe1c832fa24ac0930303a91b