### PR TITLE
Normalize cards API route and add image placeholder

### DIFF
--- a/api.Tests/CardControllerTests.cs
+++ b/api.Tests/CardControllerTests.cs
@@ -26,7 +26,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         await factory.ResetDatabaseAsync();
         using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
 
-        var pageOneResponse = await client.GetAsync("/api/card?game=Magic&page=1&pageSize=1");
+        var pageOneResponse = await client.GetAsync("/api/cards/search?game=Magic&page=1&pageSize=1");
         pageOneResponse.EnsureSuccessStatusCode();
         var pageOne = await ReadPagedAsync<CardListItemResponse>(pageOneResponse);
 
@@ -34,7 +34,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         Assert.Single(pageOne.Items);
         Assert.Equal("Goblin Guide", pageOne.Items[0].Name);
 
-        var pageTwoResponse = await client.GetAsync("/api/card?game=Magic&page=2&pageSize=1");
+        var pageTwoResponse = await client.GetAsync("/api/cards/search?game=Magic&page=2&pageSize=1");
         pageTwoResponse.EnsureSuccessStatusCode();
         var pageTwo = await ReadPagedAsync<CardListItemResponse>(pageTwoResponse);
 
@@ -42,7 +42,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         Assert.Single(pageTwo.Items);
         Assert.Equal("Lightning Bolt", pageTwo.Items[0].Name);
 
-        var filteredResponse = await client.GetAsync("/api/card?includePrintings=true&name=bolt");
+        var filteredResponse = await client.GetAsync("/api/cards/search?includePrintings=true&name=bolt");
         filteredResponse.EnsureSuccessStatusCode();
         var filtered = await ReadPagedAsync<CardDetailResponse>(filteredResponse);
 
@@ -60,7 +60,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         await factory.ResetDatabaseAsync();
         using var client = factory.CreateClient().WithUser(TestDataSeeder.BobUserId);
 
-        var response = await client.GetAsync($"/api/card/{TestDataSeeder.LightningBoltCardId}");
+        var response = await client.GetAsync($"/api/cards/{TestDataSeeder.LightningBoltCardId}");
         response.EnsureSuccessStatusCode();
         var detail = await response.Content.ReadFromJsonAsync<CardDetailResponse>(_jsonOptions);
 
@@ -70,7 +70,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         Assert.Equal(3, detail.Printings.Count);
         Assert.Contains(detail.Printings, p => p.Id == TestDataSeeder.ExtraMagicPrintingId);
 
-        var missing = await client.GetAsync("/api/card/9999");
+        var missing = await client.GetAsync("/api/cards/9999");
         Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
     }
 
@@ -81,7 +81,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         using var client = factory.CreateClient().AsAdmin();
 
         var createResponse = await client.PostAsJsonAsync(
-            "/api/card/printing",
+            "/api/cards/printing",
             new
             {
                 cardId = TestDataSeeder.LightningBoltCardId,
@@ -95,7 +95,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         Assert.Equal(HttpStatusCode.NoContent, createResponse.StatusCode);
 
         var createdDetail = await client.GetFromJsonAsync<CardDetailResponse>(
-            $"/api/card/{TestDataSeeder.LightningBoltCardId}",
+            $"/api/cards/{TestDataSeeder.LightningBoltCardId}",
             _jsonOptions);
 
         Assert.NotNull(createdDetail);
@@ -106,7 +106,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
             p.ImageUrl == "https://img.example.com/bolt-champions.png");
 
         var updateResponse = await client.PostAsJsonAsync(
-            "/api/card/printing",
+            "/api/cards/printing",
             new
             {
                 id = TestDataSeeder.LightningBoltBetaPrintingId,
@@ -119,7 +119,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
 
         var updatedDetail = await client.GetFromJsonAsync<CardDetailResponse>(
-            $"/api/card/{TestDataSeeder.LightningBoltCardId}",
+            $"/api/cards/{TestDataSeeder.LightningBoltCardId}",
             _jsonOptions);
 
         var updatedPrinting = Assert.Single(updatedDetail!.Printings, p => p.Id == TestDataSeeder.LightningBoltBetaPrintingId);
@@ -158,13 +158,13 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
         };
 
         var response = await client.PostAsJsonAsync(
-            $"/api/card/{TestDataSeeder.GoblinGuideCardId}/printings/import",
+            $"/api/cards/{TestDataSeeder.GoblinGuideCardId}/printings/import",
             payload);
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
         var detail = await client.GetFromJsonAsync<CardDetailResponse>(
-            $"/api/card/{TestDataSeeder.GoblinGuideCardId}",
+            $"/api/cards/{TestDataSeeder.GoblinGuideCardId}",
             _jsonOptions);
 
         Assert.NotNull(detail);
@@ -185,7 +185,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
 
         using var userClient = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
         var userResponse = await userClient.PostAsJsonAsync(
-            "/api/card/printing",
+            "/api/cards/printing",
             new
             {
                 cardId = TestDataSeeder.LightningBoltCardId,
@@ -196,7 +196,7 @@ public class CardControllerTests(CustomWebApplicationFactory factory)
 
         using var anonymousClient = factory.CreateClient();
         var anonResponse = await anonymousClient.PostAsJsonAsync(
-            "/api/card/printing",
+            "/api/cards/printing",
             new
             {
                 cardId = TestDataSeeder.LightningBoltCardId,

--- a/api.Tests/CardsRouteContractTests.cs
+++ b/api.Tests/CardsRouteContractTests.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Threading.Tasks;
+using api.Tests.Fixtures;
+using api.Tests.Helpers;
+using Xunit;
+
+namespace api.Tests;
+
+public class CardsRouteContractTests(CustomWebApplicationFactory factory)
+    : IClassFixture<CustomWebApplicationFactory>
+{
+    [Fact]
+    public async Task Singular_path_returns_404()
+    {
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+        var res = await client.GetAsync("/api/card?skip=0&take=1");
+        Assert.Equal(HttpStatusCode.NotFound, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Plural_path_returns_200()
+    {
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+        var res = await client.GetAsync("/api/cards?skip=0&take=1");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+    }
+}

--- a/api/Features/Cards/CardsController.cs
+++ b/api/Features/Cards/CardsController.cs
@@ -16,9 +16,11 @@ namespace api.Features.Cards;
 
 [ApiController]
 [RequireUserHeader]
-[Route("api/card")]
+[Route("api/cards")]
 public class CardsController : ControllerBase
 {
+    private const string PlaceholderCardImage = "/images/placeholders/card-3x4.png";
+
     private readonly AppDbContext _db;
     private readonly IMapper _mapper;
 
@@ -98,7 +100,7 @@ public class CardsController : ControllerBase
                         Number = p.Number,
                         Rarity = p.Rarity,
                         Style = p.Style,
-                        ImageUrl = p.ImageUrl
+                        ImageUrl = string.IsNullOrEmpty(p.ImageUrl) ? PlaceholderCardImage : p.ImageUrl
                     })
                     .FirstOrDefault()
             })
@@ -113,6 +115,11 @@ public class CardsController : ControllerBase
             NextSkip = nextSkip
         });
     }
+
+    // Legacy route shim for older clients calling /api/card
+    [HttpGet("/api/card")]
+    public IActionResult GetLegacy()
+        => RedirectPermanentPreserveMethod("/api/cards");
 
     // -----------------------------
     // Helpers

--- a/api/api.http
+++ b/api/api.http
@@ -1,7 +1,7 @@
 @api_HostAddress = https://localhost:7226
 
 ### Retrieve all cards
-GET {{api_HostAddress}}/api/card
+GET {{api_HostAddress}}/api/cards
 Accept: application/json
 
 ###

--- a/client-vite/src/features/cards/api.ts
+++ b/client-vite/src/features/cards/api.ts
@@ -1,4 +1,5 @@
-import axios from "axios";
+// client-vite/src/features/cards/api.ts
+import { api } from "@/lib/api"; // <-- shared axios instance with X-User-Id interceptor
 import type { CardSummary } from "@/components/CardTile";
 
 export type CardsPageParams = {
@@ -7,6 +8,7 @@ export type CardsPageParams = {
   skip: number;
   take: number;
 };
+
 export type CardsPage = {
   items: CardSummary[];
   total: number;
@@ -20,23 +22,23 @@ export async function fetchCardsPage({ q, games, skip, take }: CardsPageParams):
   params.set("skip", String(skip));
   params.set("take", String(take));
 
-  const res = await axios.get(`/api/cards?${params.toString()}`);
+  // Use shared client to retain X-User-Id header propagation
+  const res = await api.get(`/api/cards?${params.toString()}`);
 
-  const rawItems: any[] = res.data.items ?? [];
+  const rawItems: any[] = res.data?.items ?? [];
   const items: CardSummary[] = rawItems.map((item) => ({
-    id: item.cardId ?? item.id ?? item.cardID ?? item.card_id ?? item.cardid ?? item.Id ?? "",
+    id: item.cardId ?? item.id ?? item.Id ?? "",
     name: item.name,
     game: item.game,
-    cardType: item.cardType ?? item.type ?? null,
-    imageUrl: item.primary?.imageUrl ?? item.imageUrl ?? item.images?.small ?? null,
-    setName: item.primary?.set ?? item.setName ?? item.set ?? null,
-    number: item.primary?.number ?? item.number ?? item.collectorNumber ?? null,
+    imageUrl: item.primary?.imageUrl ?? item.imageUrl ?? null,
+    setName: item.primary?.set ?? item.setName ?? null,
+    number: item.primary?.number ?? item.number ?? null,
     rarity: item.primary?.rarity ?? item.rarity ?? null,
   }));
 
   return {
     items,
-    total: res.data.total ?? 0,
-    nextSkip: res.data.nextSkip ?? (items.length < take ? null : skip + items.length),
+    total: res.data?.total ?? 0,
+    nextSkip: res.data?.nextSkip ?? (items.length < take ? null : skip + items.length),
   };
 }

--- a/client-vite/src/features/cards/api.ts
+++ b/client-vite/src/features/cards/api.ts
@@ -1,44 +1,42 @@
-import http from "@/lib/http";
+import axios from "axios";
 import type { CardSummary } from "@/components/CardTile";
 
-// Adjust to your server API. This assumes offset pagination with skip/take.
 export type CardsPageParams = {
   q?: string;
-  games?: string[]; // e.g., ["Magic","Lorcana"]
+  games?: string[];
   skip: number;
   take: number;
 };
 export type CardsPage = {
   items: CardSummary[];
-  total?: number;
-  nextSkip?: number | null;
+  total: number;
+  nextSkip: number | null;
 };
 
 export async function fetchCardsPage({ q, games, skip, take }: CardsPageParams): Promise<CardsPage> {
-  const res = await http.get("card", {
-    params: {
-      ...(q ? { q } : {}),
-      ...(games && games.length ? { game: games.join(",") } : {}),
-      skip,
-      take,
-    },
-  });
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  if (games?.length) params.set("game", games.join(","));
+  params.set("skip", String(skip));
+  params.set("take", String(take));
 
-  const rawItems = (res.data.items ?? res.data.results ?? []) as any[];
-  const items: CardSummary[] = rawItems.map((r) => ({
-    id: String(r.cardId ?? r.id ?? r.cardID ?? r.card_id ?? r.cardid ?? r.Id ?? ""),
-    name: r.name,
-    game: r.game,
-    cardType: r.cardType ?? r.type ?? null,
-    imageUrl: r.primary?.imageUrl ?? r.imageUrl ?? r.image_url ?? r.images?.small ?? null,
-    setName: r.primary?.set ?? r.setName ?? r.set ?? null,
-    number: r.primary?.number ?? r.number ?? r.collectorNumber ?? null,
-    rarity: r.primary?.rarity ?? r.rarity ?? null,
+  const res = await axios.get(`/api/cards?${params.toString()}`);
+
+  const rawItems: any[] = res.data.items ?? [];
+  const items: CardSummary[] = rawItems.map((item) => ({
+    id: item.cardId ?? item.id ?? item.cardID ?? item.card_id ?? item.cardid ?? item.Id ?? "",
+    name: item.name,
+    game: item.game,
+    cardType: item.cardType ?? item.type ?? null,
+    imageUrl: item.primary?.imageUrl ?? item.imageUrl ?? item.images?.small ?? null,
+    setName: item.primary?.set ?? item.setName ?? item.set ?? null,
+    number: item.primary?.number ?? item.number ?? item.collectorNumber ?? null,
+    rarity: item.primary?.rarity ?? item.rarity ?? null,
   }));
 
   return {
     items,
-    total: res.data.total,
-    nextSkip: res.data.nextSkip ?? (items.length < take ? null : skip + take),
+    total: res.data.total ?? 0,
+    nextSkip: res.data.nextSkip ?? (items.length < take ? null : skip + items.length),
   };
 }


### PR DESCRIPTION
## Summary
- update the cards controller route to use /api/cards as the canonical endpoint
- add a permanent redirect shim for legacy /api/card clients
- ensure card DTOs fall back to a placeholder image when a printing lacks a URL

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e281440518832f934bcc83ca33c41d