### PR TITLE
Fix API client base usage and proxy configuration

### DIFF
--- a/client-vite/.env.example
+++ b/client-vite/.env.example
@@ -3,3 +3,6 @@ VITE_API_BASE=https://localhost:7226/api
 
 # Legacy (deprecated) variable still recognized for compatibility
 # VITE_API_BASE_URL=https://localhost:7226/api
+
+# Optional: override the Vite dev server proxy target when using a relative API base
+# VITE_DEV_SERVER_PROXY_TARGET=https://localhost:7226

--- a/client-vite/README.md
+++ b/client-vite/README.md
@@ -8,11 +8,14 @@ The API base URL is configured through environment variables:
 
 - `VITE_API_BASE` (**preferred**) – points at the root of the API server (for example `https://api.example.com` or `/api`).
 - `VITE_API_BASE_URL` (**deprecated**) – legacy name still recognized for compatibility.
+- `VITE_DEV_SERVER_PROXY_TARGET` (optional) – overrides the HTTPS target used by the Vite dev server proxy when `VITE_API_BASE` is relative.
 
 Only one value is required. When both are present, `VITE_API_BASE` wins. During development the client logs warnings when:
 
 - neither variable is defined (falls back to `/api`), or
 - only the deprecated `VITE_API_BASE_URL` is found.
+
+Best practice is to point `VITE_API_BASE` at the actual backend origin in every environment (for example `https://localhost:7226/api` locally). When the base is absolute, Axios connects to the API directly and the Vite proxy automatically disables itself. If you intentionally use a relative base such as `/api`, the proxy remains active and forwards requests to `VITE_DEV_SERVER_PROXY_TARGET` (defaulting to `https://localhost:7226`).
 
 Copy `.env.example` to `.env.local` (or `.env`) and adjust the values as needed.
 

--- a/client-vite/src/features/cards/api.ts
+++ b/client-vite/src/features/cards/api.ts
@@ -73,7 +73,7 @@ export async function fetchCardsPage({
   params.set("skip", String(skip));
   params.set("take", String(take));
 
-  const res = await api.get<RawCardsResponse>(`/api/cards?${params.toString()}`);
+  const res = await api.get<RawCardsResponse>("cards", { params });
   const data: RawCardsResponse = res.data ?? {};
 
   const rawItems: ReadonlyArray<RawCard> = data.items ?? data.Items ?? [];

--- a/client-vite/src/lib/http.ts
+++ b/client-vite/src/lib/http.ts
@@ -81,14 +81,12 @@ http.interceptors.request.use((cfg: Cfg) => {
         // eslint-disable-next-line no-console
         console.warn(
           `[http] Absolute same-origin path "${url}" bypasses axios baseURL "${base}". ` +
-            'Converted to relative path. Use "cards" instead of "/cards", ' +
+            'Use "cards" instead of "/cards", ' +
             "or pass { suppressBaseURLWarning: true }, " +
             `or allow via VITE_HTTP_ABS_OK="${ABSOLUTE_OK_PREFIXES.join(",")}".`
         );
         warnedOnce.add(key);
       }
-      // Minimal fix: make it relative so baseURL joins correctly.
-      cfg.url = url.slice(1);
     }
   }
 

--- a/client-vite/vite.config.ts
+++ b/client-vite/vite.config.ts
@@ -1,21 +1,30 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { fileURLToPath, URL } from "node:url";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
-    },
-  },
-  server: {
-    proxy: {
-      "/api": {
-        target: "https://localhost:7226",
-        changeOrigin: true,
-        secure: false,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const apiBase = env.VITE_API_BASE || env.VITE_API_BASE_URL || "";
+  const shouldProxy = !apiBase || apiBase.startsWith("/");
+  const proxyTarget = env.VITE_DEV_SERVER_PROXY_TARGET || "https://localhost:7226";
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
-  },
+    server: shouldProxy
+      ? {
+          proxy: {
+            "/api": {
+              target: proxyTarget,
+              changeOrigin: true,
+              secure: false,
+            },
+          },
+        }
+      : undefined,
+  };
 });


### PR DESCRIPTION
## Summary
- have the cards data loader request paths relative to the shared axios base URL
- stop the dev-only interceptor from rewriting absolute same-origin URLs while still warning
- make the Vite dev proxy conditional on the configured API base and document the related env vars

## Testing
- npm install --no-progress --no-audit --fund=false *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b1e4d30c832f88d2870bb59b1a88