### PR TITLE
Update VS Code launch configuration to .NET 9

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "api",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}/api/bin/Debug/net8.0/api.dll",
+      "program": "${workspaceFolder}/api/bin/Debug/net9.0/api.dll",
       "cwd": "${workspaceFolder}/api",
       "env": {
         "ASPNETCORE_URLS": "http://0.0.0.0:5229;https://0.0.0.0:7226"


### PR DESCRIPTION
## Summary
- point the VS Code launch profile at the net9.0 build output for the API project

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d1b95604832f9d4a82969d91742d