### PR TITLE
Fix wishlist search parameter mismatch and optimize filtering

### DIFF
--- a/api.Tests/WishlistControllerTests.cs
+++ b/api.Tests/WishlistControllerTests.cs
@@ -9,6 +9,7 @@ using api.Data;
 using api.Features.Collections.Dtos;
 using api.Features.Wishlists.Dtos;
 using api.Tests.Fixtures;
+using api.Shared;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -131,8 +132,9 @@ public class WishlistControllerTests(CustomWebApplicationFactory factory) : ICla
 
         var collectionResponse = await client.GetAsync($"/api/collection?cardPrintingId={TestDataSeeder.LightningBoltBetaPrintingId}");
         collectionResponse.EnsureSuccessStatusCode();
-        var collectionItems = await collectionResponse.Content.ReadFromJsonAsync<List<UserCardItemResponse>>(JsonOptions);
-        var collectionItem = Assert.Single(collectionItems!);
+        var collectionPayload = await collectionResponse.Content
+            .ReadFromJsonAsync<Paged<UserCardItemResponse>>(JsonOptions);
+        var collectionItem = Assert.Single(collectionPayload!.Items);
         Assert.Equal(1, collectionItem.QuantityOwned);
     }
 

--- a/api/Features/Wishlists/WishlistsController.cs
+++ b/api/Features/Wishlists/WishlistsController.cs
@@ -92,8 +92,10 @@ public class WishlistsController : ControllerBase
             query = query.Where(uc => uc.CardPrinting.Rarity == rarity);
         if (!string.IsNullOrWhiteSpace(name))
         {
-            var loweredName = name.ToLower();
-            query = query.Where(uc => uc.CardPrinting.Card.Name.ToLower().Contains(loweredName));
+            var pattern = $"%{name.Trim()}%";
+            query = query.Where(uc => EF.Functions.Like(
+                EF.Functions.Collate(uc.CardPrinting.Card.Name, "NOCASE"),
+                pattern));
         }
         if (cardPrintingId.HasValue)
             query = query.Where(uc => uc.CardPrintingId == cardPrintingId.Value);

--- a/client-vite/src/pages/WishlistPage.tsx
+++ b/client-vite/src/pages/WishlistPage.tsx
@@ -62,7 +62,7 @@ export default function WishlistPage() {
     queryFn: async () => {
       if (!userId) throw new Error("User not selected");
       const res = await http.get<Paged<WishlistItemDto>>(`user/${userId}/wishlist`, {
-        params: { page, pageSize, q, game: gameCsv },
+        params: { page, pageSize, name: q || undefined, game: gameCsv },
       });
       return res.data;
     },

--- a/client-vite/src/pages/__tests__/WishlistPage.test.tsx
+++ b/client-vite/src/pages/__tests__/WishlistPage.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import WishlistPage from "../WishlistPage";
+import http from "@/lib/http";
+
+vi.mock("@/state/useUser", () => ({
+  useUser: () => ({
+    userId: 42,
+    setUserId: () => {},
+    users: [],
+    refreshUsers: () => Promise.resolve(),
+  }),
+}));
+
+describe("WishlistPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("includes the name query parameter when a search term is present", async () => {
+    const getMock = vi.spyOn(http, "get").mockResolvedValue({
+      data: { items: [], total: 0, page: 1, pageSize: 50 },
+    });
+
+    const client = new QueryClient();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/wishlist?q=bolt"]}>
+          <QueryClientProvider client={client}>
+            <WishlistPage />
+          </QueryClientProvider>
+        </MemoryRouter>
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getMock).toHaveBeenCalledWith(
+      "user/42/wishlist",
+      expect.objectContaining({
+        params: expect.objectContaining({ name: "bolt" }),
+      })
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    client.clear();
+  });
+});


### PR DESCRIPTION
## Summary
- align the wishlist page client call with the API by sending the search term as `name`
- optimize the wishlist name filter to use a NOCASE collated LIKE for better database performance
- cover the wishlist page request parameters with a new client test and improve the collection test deserialization to use the paged shape

## Testing
- ⚠️ `dotnet test` *(unavailable: dotnet CLI not installed in environment)*
- ⚠️ `npm install` *(failed: npm registry forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e32d057174832f8bb6e33c90901d4f