### PR TITLE
Tune virtualized card grid layout parameters

### DIFF
--- a/client-vite/src/components/VirtualizedCardGrid.tsx
+++ b/client-vite/src/components/VirtualizedCardGrid.tsx
@@ -77,7 +77,7 @@ export default function VirtualizedCardGrid({
     if (last.index >= rowCount - 3 && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [rowVirtualizer.getVirtualItems(), rowCount, hasNextPage, fetchNextPage, isFetchingNextPage]); // eslint-disable-line
+  }, [rowVirtualizer.getVirtualItems(), rowCount, hasNextPage, fetchNextPage, isFetchingNextPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div ref={scrollRef} className="h-full w-full overflow-auto">

--- a/client-vite/src/components/VirtualizedCardGrid.tsx
+++ b/client-vite/src/components/VirtualizedCardGrid.tsx
@@ -48,7 +48,10 @@ export default function VirtualizedCardGrid({
   }, [containerWidth, minTileWidth, colGap]);
 
   const tileWidth = useMemo(() => {
-    if (columns <= 1) return Math.max(1, Math.floor(containerWidth)); // single column clamp
+    // In single-column mode, we allow the card to expand and fill the entire container width
+    // for better aesthetics and use of space, rather than clamping it to minTileWidth.
+    // If this is not desired, replace 'containerWidth' with 'minTileWidth' below.
+    if (columns <= 1) return Math.max(1, Math.floor(containerWidth));
     const totalGap = colGap * (columns - 1);
     const w = Math.floor((containerWidth - totalGap) / columns);
     return w > 0 ? w : minTileWidth;

--- a/client-vite/src/components/VirtualizedCardGrid.tsx
+++ b/client-vite/src/components/VirtualizedCardGrid.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import CardTile, { CardSummary } from "./CardTile";
 
+// props
 type Props = {
   items: CardSummary[];
   isFetchingNextPage: boolean;
@@ -11,6 +12,8 @@ type Props = {
   minTileWidth?: number; // px; default 220
   rowGap?: number; // px; default 12
   colGap?: number; // px; default 12
+  overscan?: number; // default 6
+  footerHeight?: number; // default 88
 };
 
 export default function VirtualizedCardGrid({
@@ -22,17 +25,17 @@ export default function VirtualizedCardGrid({
   minTileWidth = 220,
   rowGap = 12,
   colGap = 12,
+  overscan = 6,
+  footerHeight = 88,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
 
-  // Track container width to compute columns responsively
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     const ro = new ResizeObserver((entries) => {
-      const w = entries[0].contentRect.width;
-      setContainerWidth(w);
+      setContainerWidth(entries[0].contentRect.width);
     });
     ro.observe(el);
     return () => ro.disconnect();
@@ -40,19 +43,19 @@ export default function VirtualizedCardGrid({
 
   const columns = useMemo(() => {
     if (containerWidth <= 0) return 1;
-    const cols = Math.max(1, Math.floor((containerWidth + colGap) / (minTileWidth + colGap)));
-    return cols;
+    const cols = Math.floor((containerWidth + colGap) / (minTileWidth + colGap));
+    return Number.isFinite(cols) && cols > 0 ? cols : 1;
   }, [containerWidth, minTileWidth, colGap]);
 
   const tileWidth = useMemo(() => {
-    if (columns === 0) return minTileWidth;
+    if (columns <= 1) return Math.max(1, Math.floor(containerWidth)); // single column clamp
     const totalGap = colGap * (columns - 1);
     const w = Math.floor((containerWidth - totalGap) / columns);
-    return w;
+    return w > 0 ? w : minTileWidth;
   }, [columns, containerWidth, colGap, minTileWidth]);
 
-  // 3:4 aspect + header area ~88px
-  const tileHeight = Math.floor((tileWidth * 4) / 3) + 88;
+  // 3:4 image + footer
+  const tileHeight = Math.floor((tileWidth * 4) / 3) + footerHeight;
 
   const rowCount = Math.ceil(items.length / columns);
 
@@ -60,10 +63,9 @@ export default function VirtualizedCardGrid({
     count: rowCount,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => tileHeight + rowGap,
-    overscan: 10,
+    overscan,
   });
 
-  // Auto-load next page when last row comes into view
   useEffect(() => {
     if (!hasNextPage || !fetchNextPage) return;
     const vItems = rowVirtualizer.getVirtualItems();
@@ -72,14 +74,11 @@ export default function VirtualizedCardGrid({
     if (last.index >= rowCount - 3 && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [rowVirtualizer, rowCount, hasNextPage, fetchNextPage, isFetchingNextPage]);
+  }, [rowVirtualizer.getVirtualItems(), rowCount, hasNextPage, fetchNextPage, isFetchingNextPage]); // eslint-disable-line
 
   return (
     <div ref={scrollRef} className="h-full w-full overflow-auto">
-      <div
-        className="relative"
-        style={{ height: rowVirtualizer.getTotalSize() }}
-      >
+      <div className="relative" style={{ height: rowVirtualizer.getTotalSize() }}>
         {rowVirtualizer.getVirtualItems().map((vRow) => {
           const rowIndex = vRow.index;
           const startY = vRow.start;
@@ -88,11 +87,7 @@ export default function VirtualizedCardGrid({
           const rowItems = items.slice(start, end);
 
           return (
-            <div
-              key={rowIndex}
-              className="absolute left-0 w-full"
-              style={{ transform: `translateY(${startY}px)` }}
-            >
+            <div key={rowIndex} className="absolute left-0 w-full" style={{ transform: `translateY(${startY}px)` }}>
               <div
                 className="grid"
                 style={{
@@ -112,9 +107,7 @@ export default function VirtualizedCardGrid({
       </div>
 
       {isFetchingNextPage && (
-        <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-          Loading more…
-        </div>
+        <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">Loading more…</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add overscan and footer height controls to virtualized card grid props
- refine column and tile sizing logic for stability
- apply configurable overscan to react-virtual hook

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fa8754a8832fb28d01e6b0836b2e