### PR TITLE
Adjust card grid virtualization heuristics

### DIFF
--- a/client-vite/src/components/VirtualizedCardGrid.tsx
+++ b/client-vite/src/components/VirtualizedCardGrid.tsx
@@ -11,6 +11,8 @@ type Props = {
   minTileWidth?: number; // px; default 220
   rowGap?: number; // px; default 12
   colGap?: number; // px; default 12
+  overscan?: number; // rows; default 6
+  footerHeight?: number; // px; default 88
 };
 
 export default function VirtualizedCardGrid({
@@ -22,6 +24,8 @@ export default function VirtualizedCardGrid({
   minTileWidth = 220,
   rowGap = 12,
   colGap = 12,
+  overscan = 6,
+  footerHeight = 88,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -51,8 +55,8 @@ export default function VirtualizedCardGrid({
     return w;
   }, [columns, containerWidth, colGap, minTileWidth]);
 
-  // 3:4 aspect + header area ~88px
-  const tileHeight = Math.floor((tileWidth * 4) / 3) + 88;
+  // 3:4 aspect + footer/header area
+  const tileHeight = Math.floor((tileWidth * 4) / 3) + footerHeight;
 
   const rowCount = Math.ceil(items.length / columns);
 
@@ -60,7 +64,7 @@ export default function VirtualizedCardGrid({
     count: rowCount,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => tileHeight + rowGap,
-    overscan: 10,
+    overscan,
   });
 
   // Auto-load next page when last row comes into view

--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -7,7 +7,8 @@ import { fetchCardsPage } from "@/features/cards/api";
 import { useSearchParams } from "react-router-dom";
 import { useUser } from "@/state/useUser";
 
-const PAGE_SIZE = 60; // tune per perf
+// Heuristic: smaller page on low-core devices to reduce memory pressure.
+const PAGE_SIZE = (navigator?.hardwareConcurrency ?? 4) <= 4 ? 60 : 96;
 
 export default function CardsPage() {
   const { userId } = useUser();
@@ -49,6 +50,8 @@ export default function CardsPage() {
           console.debug("card", c.id);
         }}
         minTileWidth={220}
+        overscan={(navigator?.hardwareConcurrency ?? 4) <= 4 ? 8 : 6}
+        footerHeight={88}
       />
     </div>
   );

--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -50,7 +50,7 @@ export default function CardsPage() {
           console.debug("card", c.id);
         }}
         minTileWidth={220}
-        overscan={(navigator?.hardwareConcurrency ?? 4) <= 4 ? 8 : 6}
+        overscan={(navigator?.hardwareConcurrency ?? 4) <= 4 ? 6 : 8}
         footerHeight={88}
       />
     </div>


### PR DESCRIPTION
## Summary
- tune card pagination size and grid overscan based on hardware concurrency
- expose configurable overscan and footer height on the virtualized card grid component
- update card tile sizing to respect configurable footer height while preserving 3:4 aspect ratio

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4fab3d450832f9a0d51575a8a13d8