### PR TITLE
Add card facet API re-exports

### DIFF
--- a/client-vite/src/features/cards/api/index.ts
+++ b/client-vite/src/features/cards/api/index.ts
@@ -1,5 +1,15 @@
-export { fetchCardsPage } from "./list";
-export type { CardsPage, CardsPageParams } from "./list";
+export {
+  fetchCardsPage,
+  fetchCardGames,
+  fetchCardSets,
+  fetchCardRarities,
+} from "./list";
+export type {
+  CardsPage,
+  CardsPageParams,
+  CardFacetSets,
+  CardFacetRarities,
+} from "./list";
 export type {
   CardDetail,
   CardPrintingDetail,


### PR DESCRIPTION
## Summary
- re-export card facet fetch helpers and their types from the cards API index so downstream imports stay consistent

## Testing
- npm run build *(fails: missing TypeScript/vite type definitions without npm install)*
- npm run test -- --run *(fails: vitest not available without npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68e519814a30832f88cc9916f73814dd