### PR TITLE
Add card modal state management on cards page

### DIFF
--- a/client-vite/src/pages/CardsPage.test.tsx
+++ b/client-vite/src/pages/CardsPage.test.tsx
@@ -4,7 +4,20 @@ import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/VirtualizedCardGrid", () => ({
-  default: () => <div data-testid="grid" />,
+  default: ({ items, onCardClick }: { items: Array<{ id: number | string }>; onCardClick?: (card: unknown) => void }) => (
+    <div data-testid="grid">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          data-testid={`card-${item.id}`}
+          onClick={() => onCardClick?.(item)}
+        >
+          Card {item.id}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock("@/features/cards/filters/FiltersRail", () => ({
@@ -15,18 +28,35 @@ vi.mock("@/features/cards/filters/PillsBar", () => ({
   default: () => <div data-testid="pills-bar" />,
 }));
 
+vi.mock("@/features/cards/components/CardModal", () => ({
+  default: ({ open, cardId }: { open: boolean; cardId: number }) =>
+    open ? <div data-testid="card-modal">Card {cardId}</div> : null,
+}));
+
 vi.mock("@/state/useUser", () => ({
   useUser: () => ({ userId: 1 }),
 }));
 
-const querySpy = vi.fn(() => ({
+type QueryResult = {
+  data: unknown;
+  isError: boolean;
+  isFetching: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+};
+
+const createQueryResult = (overrides: Partial<QueryResult> = {}): QueryResult => ({
   data: undefined,
   isError: false,
   isFetching: false,
   isFetchingNextPage: false,
   hasNextPage: false,
   fetchNextPage: vi.fn(),
-}));
+  ...overrides,
+});
+
+const querySpy = vi.fn(() => createQueryResult());
 
 vi.mock("@tanstack/react-query", async () => {
   const actual = await vi.importActual<Record<string, unknown>>("@tanstack/react-query");
@@ -40,7 +70,8 @@ import CardsPage from "./CardsPage";
 
 describe("CardsPage", () => {
   beforeEach(() => {
-    querySpy.mockClear();
+    querySpy.mockReset();
+    querySpy.mockImplementation(() => createQueryResult());
   });
 
   it("includes filters in the query key", async () => {
@@ -77,6 +108,52 @@ describe("CardsPage", () => {
       { userId: 1, filters: ["", "Magic", "", "Rare"] },
     ]);
     expect(latestOptions?.queryKey).not.toBe(initialOptions?.queryKey);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("opens the card modal when a card is clicked", async () => {
+    const card = {
+      id: 7,
+      primaryPrintingId: 42,
+      name: "Test Card",
+      game: "Test",
+    };
+
+    querySpy.mockImplementation(() =>
+      createQueryResult({
+        data: {
+          pages: [
+            {
+              items: [card],
+              nextSkip: null,
+            },
+          ],
+        },
+      })
+    );
+
+    const router = createMemoryRouter([
+      { path: "/", element: <CardsPage /> },
+    ]);
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<RouterProvider router={router} />);
+    });
+
+    const cardButton = container.querySelector<HTMLButtonElement>("[data-testid='card-7']");
+    expect(cardButton).not.toBeNull();
+
+    await act(async () => {
+      cardButton?.click();
+    });
+
+    expect(container.querySelector("[data-testid='card-modal']")).not.toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import VirtualizedCardGrid from "@/components/VirtualizedCardGrid";
 import type { CardSummary } from "@/components/CardTile";
@@ -7,6 +7,7 @@ import { fetchCardsPage } from "@/features/cards/api";
 import FiltersRail from "@/features/cards/filters/FiltersRail";
 import PillsBar from "@/features/cards/filters/PillsBar";
 import { useCardFilters } from "@/features/cards/filters/useCardFilters";
+import CardModal from "@/features/cards/components/CardModal";
 import { useUser } from "@/state/useUser";
 import { pageSizeForDevice, overscanForDevice } from "@/lib/perf";
 
@@ -17,6 +18,8 @@ export default function CardsPage() {
   const { userId } = useUser();
   const { filters, toQueryKey } = useCardFilters();
   const [isMobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [selectedCardId, setSelectedCardId] = useState<number | null>(null);
+  const [selectedPrintingId, setSelectedPrintingId] = useState<number | null>(null);
 
   const filterKey = toQueryKey();
   const queryKey = useMemo(() => ["cards", { userId, filters: filterKey }], [userId, filterKey]);
@@ -42,6 +45,32 @@ export default function CardsPage() {
     () => query.data?.pages.flatMap(p => p.items) ?? [],
     [query.data]
   );
+
+  const handleModalOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setSelectedCardId(null);
+      setSelectedPrintingId(null);
+    }
+  }, []);
+
+  const handleCardClick = useCallback((card: CardSummary) => {
+    const numericId = typeof card.id === "number" ? card.id : Number(card.id);
+    if (!Number.isFinite(numericId)) return;
+    setSelectedCardId(numericId);
+    setSelectedPrintingId(card.primaryPrintingId ?? null);
+  }, []);
+
+  useEffect(() => {
+    if (selectedCardId == null) return;
+    const stillExists = items.some((card) => {
+      const numericId = typeof card.id === "number" ? card.id : Number(card.id);
+      return Number.isFinite(numericId) && numericId === selectedCardId;
+    });
+    if (!stillExists) {
+      setSelectedCardId(null);
+      setSelectedPrintingId(null);
+    }
+  }, [items, selectedCardId]);
 
   const hasNoResults = !query.isFetching && items.length === 0;
 
@@ -78,9 +107,7 @@ export default function CardsPage() {
                 isFetchingNextPage={query.isFetchingNextPage}
                 hasNextPage={query.hasNextPage}
                 fetchNextPage={() => query.fetchNextPage()}
-                onCardClick={(c) => {
-                  console.debug("card", c.id);
-                }}
+                onCardClick={handleCardClick}
                 minTileWidth={220}
                 overscan={(navigator?.hardwareConcurrency ?? 4) <= 4 ? 6 : 8}
                 footerHeight={88}
@@ -102,6 +129,12 @@ export default function CardsPage() {
           </div>
         </div>
       )}
+      <CardModal
+        open={selectedCardId != null}
+        cardId={selectedCardId ?? 0}
+        initialPrintingId={selectedPrintingId ?? undefined}
+        onOpenChange={handleModalOpenChange}
+      />
     </div>
   );
 }

--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -129,12 +129,14 @@ export default function CardsPage() {
           </div>
         </div>
       )}
-      <CardModal
-        open={selectedCardId != null}
-        cardId={selectedCardId ?? 0}
-        initialPrintingId={selectedPrintingId ?? undefined}
-        onOpenChange={handleModalOpenChange}
-      />
+      {selectedCardId != null && (
+        <CardModal
+          open={true}
+          cardId={selectedCardId}
+          initialPrintingId={selectedPrintingId ?? undefined}
+          onOpenChange={handleModalOpenChange}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- manage the selected card state in CardsPage and wire it into the CardModal
- reset modal selection when the queried card list changes and remove debug logging
- extend the CardsPage test suite to ensure clicking a card opens the modal

## Testing
- npm test -- --runInBand *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e51d593a08832f9dfc837df895b148