### PR TITLE
Add shared helper to clamp UserCard QuickAdd increments

### DIFF
--- a/api.Tests/CollectionControllerTests.cs
+++ b/api.Tests/CollectionControllerTests.cs
@@ -319,6 +319,27 @@ public class CollectionControllerTests(CustomWebApplicationFactory factory)
     }
 
     [Fact]
+    public async Task Collection_QuickAdd_ClampsAtIntMax()
+    {
+        await factory.ResetDatabaseAsync();
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/collection/items",
+            new { printingId = TestDataSeeder.ExtraMagicPrintingId, quantity = int.MaxValue - 1 });
+        createResponse.EnsureSuccessStatusCode();
+
+        var incrementResponse = await client.PostAsJsonAsync(
+            "/api/collection/items",
+            new { printingId = TestDataSeeder.ExtraMagicPrintingId, quantity = 100 });
+        incrementResponse.EnsureSuccessStatusCode();
+
+        var increment = await incrementResponse.Content.ReadFromJsonAsync<QuickAddResponse>();
+        Assert.NotNull(increment);
+        Assert.Equal(int.MaxValue, increment!.QuantityOwned);
+    }
+
+    [Fact]
     public async Task Collection_QuickAdd_RejectsInvalidQuantity()
     {
         await factory.ResetDatabaseAsync();

--- a/api.Tests/WishlistControllerTests.cs
+++ b/api.Tests/WishlistControllerTests.cs
@@ -226,6 +226,27 @@ public class WishlistControllerTests(CustomWebApplicationFactory factory) : ICla
     }
 
     [Fact]
+    public async Task Wishlist_QuickAdd_ClampsAtIntMax()
+    {
+        await factory.ResetDatabaseAsync();
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var create = await client.PostAsJsonAsync(
+            "/api/wishlist/items",
+            new { printingId = TestDataSeeder.ExtraMagicPrintingId, quantity = int.MaxValue - 1 });
+        create.EnsureSuccessStatusCode();
+
+        var increment = await client.PostAsJsonAsync(
+            "/api/wishlist/items",
+            new { printingId = TestDataSeeder.ExtraMagicPrintingId, quantity = 100 });
+        increment.EnsureSuccessStatusCode();
+
+        var result = await increment.Content.ReadFromJsonAsync<QuickAddResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(int.MaxValue, result!.QuantityWanted);
+    }
+
+    [Fact]
     public async Task Wishlist_QuickAdd_RejectsInvalidQuantity()
     {
         await factory.ResetDatabaseAsync();

--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -364,8 +364,7 @@ public class CollectionsController : ControllerBase
         }
         else
         {
-            var total = (long)card.QuantityOwned + dto.Quantity;
-            card.QuantityOwned = total > int.MaxValue ? int.MaxValue : (int)total;
+            card.QuantityOwned = UserCardMath.AddClamped(card.QuantityOwned, dto.Quantity);
         }
 
         await _db.SaveChangesAsync();

--- a/api/Features/Wishlists/WishlistsController.cs
+++ b/api/Features/Wishlists/WishlistsController.cs
@@ -326,8 +326,7 @@ public class WishlistsController : ControllerBase
         }
         else
         {
-            var total = (long)card.QuantityWanted + dto.Quantity;
-            card.QuantityWanted = total > int.MaxValue ? int.MaxValue : (int)total;
+            card.QuantityWanted = UserCardMath.AddClamped(card.QuantityWanted, dto.Quantity);
         }
 
         await _db.SaveChangesAsync();

--- a/api/Shared/UserCardMath.cs
+++ b/api/Shared/UserCardMath.cs
@@ -1,0 +1,10 @@
+namespace api.Shared;
+
+public static class UserCardMath
+{
+    public static int AddClamped(int current, int delta)
+    {
+        var total = (long)current + delta;
+        return total > int.MaxValue ? int.MaxValue : (int)total;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared UserCardMath helper to centralize AddClamped overflow protection
- use the helper in wishlist and collection QuickAdd endpoints
- add regression tests ensuring QuickAdd clamps to int.MaxValue for large increments

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e522f6737c832f81a24b962e5d43ec