### PR TITLE
Extract sparkline builder utility

### DIFF
--- a/client-vite/src/features/cards/components/CardModal.tsx
+++ b/client-vite/src/features/cards/components/CardModal.tsx
@@ -19,6 +19,7 @@ import {
   useUpsertWishlist,
   type PrintingSummary,
 } from "../api";
+import { buildSparklinePath } from "../utils/sparkline";
 
 const TABS = [
   { id: "details", label: "Details" },
@@ -129,20 +130,7 @@ export default function CardModal({ cardId, open, onOpenChange, initialPrintingI
   );
 
   const pricePoints = priceQuery.data ?? [];
-  const pricePath = useMemo(() => {
-    if (pricePoints.length === 0) return null;
-    const values = pricePoints.map((p) => p.p);
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    const range = max - min || 1;
-    return pricePoints
-      .map((point, index) => {
-        const x = pricePoints.length === 1 ? 0 : (index / (pricePoints.length - 1)) * 100;
-        const y = 100 - ((point.p - min) / range) * 100;
-        return `${index === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
-      })
-      .join(" ");
-  }, [pricePoints]);
+  const pricePath = useMemo(() => buildSparklinePath(pricePoints), [pricePoints]);
 
   const latestPrice = pricePoints.length > 0 ? pricePoints[pricePoints.length - 1].p : undefined;
 

--- a/client-vite/src/features/cards/utils/__tests__/sparkline.test.ts
+++ b/client-vite/src/features/cards/utils/__tests__/sparkline.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildSparklinePath } from "../sparkline";
+import type { PricePoint } from "../../api";
+
+describe("buildSparklinePath", () => {
+  it("returns horizontal line for flat price history", () => {
+    const points: PricePoint[] = [
+      { d: "2024-01-01", p: 5 },
+      { d: "2024-01-02", p: 5 },
+      { d: "2024-01-03", p: 5 },
+    ];
+
+    expect(buildSparklinePath(points)).toBe("M0.00,100.00 L50.00,100.00 L100.00,100.00");
+  });
+
+  it("returns ascending path for increasing prices", () => {
+    const points: PricePoint[] = [
+      { d: "2024-01-01", p: 1 },
+      { d: "2024-01-02", p: 2 },
+      { d: "2024-01-03", p: 3 },
+    ];
+
+    expect(buildSparklinePath(points)).toBe("M0.00,100.00 L50.00,50.00 L100.00,0.00");
+  });
+
+  it("handles single price point", () => {
+    const points: PricePoint[] = [{ d: "2024-01-01", p: 5 }];
+
+    expect(buildSparklinePath(points)).toBe("M0.00,100.00");
+  });
+
+  it("returns null for empty list", () => {
+    expect(buildSparklinePath([])).toBeNull();
+  });
+});

--- a/client-vite/src/features/cards/utils/sparkline.ts
+++ b/client-vite/src/features/cards/utils/sparkline.ts
@@ -1,0 +1,18 @@
+import type { PricePoint } from "../api";
+
+export function buildSparklinePath(points: PricePoint[]): string | null {
+  if (points.length === 0) return null;
+
+  const values = points.map((point) => point.p);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  return points
+    .map((point, index) => {
+      const x = points.length === 1 ? 0 : (index / (points.length - 1)) * 100;
+      const y = 100 - ((point.p - min) / range) * 100;
+      return `${index === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- add a reusable sparkline path builder for card price history
- wire CardModal to use the shared sparkline helper
- cover flat, increasing, and single-point histories with unit tests

## Testing
- npm test -- --run *(fails: vitest is unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5248031e4832fbb14d0dccaeb1751