### PR TITLE
Create shared CSV utility for card filters

### DIFF
--- a/api.Tests/CsvParsingIntegrationTests.cs
+++ b/api.Tests/CsvParsingIntegrationTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using api.Features.Cards.Dtos;
+using api.Tests.Fixtures;
+using api.Tests.Helpers;
+using Xunit;
+
+namespace api.Tests;
+
+public class CsvParsingIntegrationTests(CustomWebApplicationFactory factory)
+    : IClassFixture<CustomWebApplicationFactory>
+{
+    [Fact]
+    public async Task CardsController_ListCardsVirtualized_NormalizesCsvFilters()
+    {
+        await factory.ResetDatabaseAsync();
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var baseline = await client.GetFromJsonAsync<CardListPageResponse>("/api/cards?take=200");
+        Assert.NotNull(baseline);
+
+        var empty = await client.GetFromJsonAsync<CardListPageResponse>("/api/cards?game=&take=200");
+        Assert.NotNull(empty);
+        Assert.Equal(baseline!.Items.Select(i => i.CardId), empty!.Items.Select(i => i.CardId));
+
+        var normalized = await client.GetFromJsonAsync<CardListPageResponse>("/api/cards?game=Magic,Lorcana&take=200");
+        Assert.NotNull(normalized);
+
+        var duplicatesAndWhitespace = await client.GetFromJsonAsync<CardListPageResponse>(
+            "/api/cards?game=%20Magic%20,%20Magic%20,%20Lorcana%20&take=200");
+        Assert.NotNull(duplicatesAndWhitespace);
+
+        Assert.Equal(
+            normalized!.Items.Select(i => i.CardId),
+            duplicatesAndWhitespace!.Items.Select(i => i.CardId));
+    }
+
+    [Fact]
+    public async Task CardFacetsController_NormalizesCsvFilters()
+    {
+        await factory.ResetDatabaseAsync();
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var allSets = await client.GetFromJsonAsync<CardFacetSetsResponse>("/api/cards/facets/sets");
+        Assert.NotNull(allSets);
+
+        var emptySets = await client.GetFromJsonAsync<CardFacetSetsResponse>("/api/cards/facets/sets?game=");
+        Assert.NotNull(emptySets);
+        Assert.Null(emptySets!.Game);
+        Assert.Equal(allSets!.Sets, emptySets.Sets);
+
+        var normalizedSets = await client.GetFromJsonAsync<CardFacetSetsResponse>("/api/cards/facets/sets?game=Magic,Lorcana");
+        Assert.NotNull(normalizedSets);
+
+        var duplicatesAndWhitespaceSets = await client.GetFromJsonAsync<CardFacetSetsResponse>(
+            "/api/cards/facets/sets?game=%20Magic%20,%20Magic%20,%20Lorcana%20");
+        Assert.NotNull(duplicatesAndWhitespaceSets);
+        Assert.Null(duplicatesAndWhitespaceSets!.Game);
+        Assert.Equal(normalizedSets!.Sets, duplicatesAndWhitespaceSets.Sets);
+
+        var singleGameSets = await client.GetFromJsonAsync<CardFacetSetsResponse>("/api/cards/facets/sets?game=Magic");
+        Assert.NotNull(singleGameSets);
+
+        var duplicateSingleSets = await client.GetFromJsonAsync<CardFacetSetsResponse>(
+            "/api/cards/facets/sets?game=Magic,%20Magic%20");
+        Assert.NotNull(duplicateSingleSets);
+        Assert.Equal("Magic", duplicateSingleSets!.Game);
+        Assert.Equal(singleGameSets!.Sets, duplicateSingleSets.Sets);
+
+        var allRarities = await client.GetFromJsonAsync<CardFacetRaritiesResponse>("/api/cards/facets/rarities");
+        Assert.NotNull(allRarities);
+
+        var emptyRarities = await client.GetFromJsonAsync<CardFacetRaritiesResponse>("/api/cards/facets/rarities?game=");
+        Assert.NotNull(emptyRarities);
+        Assert.Null(emptyRarities!.Game);
+        Assert.Equal(allRarities!.Rarities, emptyRarities.Rarities);
+
+        var normalizedRarities = await client.GetFromJsonAsync<CardFacetRaritiesResponse>("/api/cards/facets/rarities?game=Magic,Lorcana");
+        Assert.NotNull(normalizedRarities);
+
+        var duplicatesAndWhitespaceRarities = await client.GetFromJsonAsync<CardFacetRaritiesResponse>(
+            "/api/cards/facets/rarities?game=%20Magic%20,%20Magic%20,%20Lorcana%20");
+        Assert.NotNull(duplicatesAndWhitespaceRarities);
+        Assert.Null(duplicatesAndWhitespaceRarities!.Game);
+        Assert.Equal(normalizedRarities!.Rarities, duplicatesAndWhitespaceRarities.Rarities);
+
+        var singleGameRarities = await client.GetFromJsonAsync<CardFacetRaritiesResponse>("/api/cards/facets/rarities?game=Magic");
+        Assert.NotNull(singleGameRarities);
+
+        var duplicateSingleRarities = await client.GetFromJsonAsync<CardFacetRaritiesResponse>(
+            "/api/cards/facets/rarities?game=Magic,%20Magic%20");
+        Assert.NotNull(duplicateSingleRarities);
+        Assert.Equal("Magic", duplicateSingleRarities!.Game);
+        Assert.Equal(singleGameRarities!.Rarities, duplicateSingleRarities.Rarities);
+    }
+}

--- a/api.Tests/CsvUtilsTests.cs
+++ b/api.Tests/CsvUtilsTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using api.Shared;
+using Xunit;
+
+namespace api.Tests;
+
+public class CsvUtilsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_ReturnsEmpty_ForNullOrWhitespace(string? value)
+    {
+        var result = CsvUtils.Parse(value);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Parse_TrimsEntries()
+    {
+        var result = CsvUtils.Parse(" Magic , Lorcana ");
+
+        Assert.Equal(new[] { "Magic", "Lorcana" }, result);
+    }
+
+    [Fact]
+    public void Parse_RemovesDuplicates_PreservingFirstOccurrence()
+    {
+        var result = CsvUtils.Parse("Magic,Magic,Lorcana,Magic");
+
+        Assert.Equal(new[] { "Magic", "Lorcana" }, result);
+    }
+
+    [Fact]
+    public void Parse_IgnoresEntriesThatBecomeEmptyAfterTrim()
+    {
+        var result = CsvUtils.Parse("Magic, , ,Lorcana");
+
+        Assert.Equal(new[] { "Magic", "Lorcana" }, result);
+    }
+}

--- a/api/Features/Cards/CardFacetsController.cs
+++ b/api/Features/Cards/CardFacetsController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using api.Data;
 using api.Features.Cards.Dtos;
 using api.Middleware;
+using api.Shared;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -39,7 +40,7 @@ public sealed class CardFacetsController : ControllerBase
     [HttpGet("sets")]
     public async Task<ActionResult<CardFacetSetsResponse>> GetSets([FromQuery] string? game, CancellationToken ct = default)
     {
-        var games = ParseCsv(game);
+        var games = CsvUtils.Parse(game);
 
         var query = _db.CardPrintings.AsNoTracking().AsQueryable();
         if (games.Count > 0)
@@ -66,7 +67,7 @@ public sealed class CardFacetsController : ControllerBase
     [HttpGet("rarities")]
     public async Task<ActionResult<CardFacetRaritiesResponse>> GetRarities([FromQuery] string? game, CancellationToken ct = default)
     {
-        var games = ParseCsv(game);
+        var games = CsvUtils.Parse(game);
 
         var query = _db.CardPrintings.AsNoTracking().AsQueryable();
         if (games.Count > 0)
@@ -90,13 +91,4 @@ public sealed class CardFacetsController : ControllerBase
         return Ok(response);
     }
 
-    private static List<string> ParseCsv(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value)) return new List<string>();
-
-        return value
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-    }
 }

--- a/api/Features/Cards/CardsController.cs
+++ b/api/Features/Cards/CardsController.cs
@@ -47,9 +47,9 @@ public class CardsController : ControllerBase
         if (take > 200) take = 200;
         if (skip < 0) skip = 0;
 
-        var games = ParseCsv(game);
-        var sets = ParseCsv(set);
-        var rarities = ParseCsv(rarity);
+        var games = CsvUtils.Parse(game);
+        var sets = CsvUtils.Parse(set);
+        var rarities = CsvUtils.Parse(rarity);
 
         IQueryable<Card> query = _db.Cards.AsNoTracking();
 
@@ -61,17 +61,17 @@ public class CardsController : ControllerBase
                 EF.Functions.Like(c.CardType, $"%{term}%"));
         }
 
-        if (games.Length > 0)
+        if (games.Count > 0)
         {
             query = query.Where(c => games.Contains(c.Game));
         }
 
-        if (sets.Length > 0)
+        if (sets.Count > 0)
         {
             query = query.Where(c => c.Printings.Any(p => sets.Contains(p.Set)));
         }
 
-        if (rarities.Length > 0)
+        if (rarities.Count > 0)
         {
             query = query.Where(c => c.Printings.Any(p => rarities.Contains(p.Rarity)));
         }

--- a/api/Shared/CsvUtils.cs
+++ b/api/Shared/CsvUtils.cs
@@ -31,8 +31,6 @@ public static class CsvUtils
             }
         }
 
-        return results.Count == 0
-            ? Array.Empty<string>()
-            : results;
+        return results;
     }
 }

--- a/api/Shared/CsvUtils.cs
+++ b/api/Shared/CsvUtils.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace api.Shared;
+
+public static class CsvUtils
+{
+    public static IReadOnlyList<string> Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Array.Empty<string>();
+        }
+
+        var segments = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var results = new List<string>(segments.Length);
+
+        foreach (var segment in segments)
+        {
+            var normalized = segment.Trim();
+            if (normalized.Length == 0)
+            {
+                continue;
+            }
+
+            if (seen.Add(normalized))
+            {
+                results.Add(normalized);
+            }
+        }
+
+        return results.Count == 0
+            ? Array.Empty<string>()
+            : results;
+    }
+}

--- a/api/Shared/CsvUtils.cs
+++ b/api/Shared/CsvUtils.cs
@@ -13,10 +13,6 @@ public static class CsvUtils
         }
 
         var segments = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length == 0)
-        {
-            return Array.Empty<string>();
-        }
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var results = new List<string>(segments.Length);


### PR DESCRIPTION
## Summary
- add a shared CsvUtils helper to normalize comma-delimited inputs
- update the Cards and CardFacets controllers to use the shared helper
- add unit and integration tests covering CSV edge cases and controller behavior

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e526a70b1c832f97acedacf2b7d9a6