### PR TITLE
Normalize card id handling in cards page

### DIFF
--- a/client-vite/src/components/CardTile.tsx
+++ b/client-vite/src/components/CardTile.tsx
@@ -2,6 +2,10 @@ import LazyImage from "./LazyImage";
 import { resolveImageUrl } from "@/lib/http";
 
 export type CardSummary = {
+  /**
+   * API responses occasionally encode identifiers as strings, so consumers
+   * should normalize this value before performing numeric comparisons.
+   */
   id: number | string;
   primaryPrintingId: number | null;
   name: string;

--- a/client-vite/src/pages/CardsPage.tsx
+++ b/client-vite/src/pages/CardsPage.tsx
@@ -14,6 +14,11 @@ import { pageSizeForDevice, overscanForDevice } from "@/lib/perf";
 // Heuristic: smaller page on low-core devices to reduce memory pressure.
 const PAGE_SIZE = pageSizeForDevice(60, 96);
 
+const normalizeCardId = (id: CardSummary["id"]): number | null => {
+  const numericId = typeof id === "number" ? id : Number(id);
+  return Number.isFinite(numericId) ? numericId : null;
+};
+
 export default function CardsPage() {
   const { userId } = useUser();
   const { filters, toQueryKey } = useCardFilters();
@@ -54,18 +59,15 @@ export default function CardsPage() {
   }, []);
 
   const handleCardClick = useCallback((card: CardSummary) => {
-    const numericId = typeof card.id === "number" ? card.id : Number(card.id);
-    if (!Number.isFinite(numericId)) return;
+    const numericId = normalizeCardId(card.id);
+    if (numericId == null) return;
     setSelectedCardId(numericId);
     setSelectedPrintingId(card.primaryPrintingId ?? null);
   }, []);
 
   useEffect(() => {
     if (selectedCardId == null) return;
-    const stillExists = items.some((card) => {
-      const numericId = typeof card.id === "number" ? card.id : Number(card.id);
-      return Number.isFinite(numericId) && numericId === selectedCardId;
-    });
+    const stillExists = items.some((card) => normalizeCardId(card.id) === selectedCardId);
     if (!stillExists) {
       setSelectedCardId(null);
       setSelectedPrintingId(null);


### PR DESCRIPTION
## Summary
- add a normalizeCardId helper on the cards page so card selection uses a single normalization path
- document why CardSummary keeps a union id type for downstream normalization

## Testing
- npm run lint *(fails: missing @eslint/js dependency because npm install is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e528c29a38832faab354aa40b39e0b