### PR TITLE
Add tests for useIncludeProxies hook

### DIFF
--- a/client-vite/src/hooks/__tests__/useIncludeProxies.36_38.spec.tsx
+++ b/client-vite/src/hooks/__tests__/useIncludeProxies.36_38.spec.tsx
@@ -108,18 +108,18 @@ describe("useIncludeProxies", () => {
   });
 
   it("includes the includeProxies discriminator in query keys", () => {
-    const collectionKeyWithProxies = collectionKeys.list({
+    const commonCollectionParams = {
       userId: 1,
       page: 1,
       pageSize: 25,
       filters: { q: "", game: "", set: "", rarity: "" },
+    };
+    const collectionKeyWithProxies = collectionKeys.list({
+      ...commonCollectionParams,
       includeProxies: true,
     });
     const collectionKeyWithoutProxies = collectionKeys.list({
-      userId: 1,
-      page: 1,
-      pageSize: 25,
-      filters: { q: "", game: "", set: "", rarity: "" },
+      ...commonCollectionParams,
       includeProxies: false,
     });
 


### PR DESCRIPTION
## Summary
- add a MemoryRouter-backed probe to exercise the useIncludeProxies hook
- verify localStorage interactions, query parameter precedence, and cache key isolation

## Testing
- npm test -- useIncludeProxies *(fails: vitest binary unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e561a7c6a4832f855b583a978a0020