### PR TITLE
Add EF migrations scripts and README docs (#42)

### DIFF
--- a/api/Data/Migrations/.gitkeep
+++ b/api/Data/Migrations/.gitkeep
@@ -1,0 +1,1 @@
+# Keep migrations folder tracked

--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@ PowerShell:
 Bash:
 
 ```bash
-./scripts/ef-migrations.sh "AddCardsTable"
+./api/scripts/ef-migrations.sh "AddCardsTable"
 ```
 
 ### What the scripts do

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,53 @@
+# Trading Card Game Tracker API
+
+## Entity Framework Migrations
+
+Use the provided scripts from the repository root to keep migrations consistent across environments.
+
+### One-liner usage
+
+PowerShell:
+
+```powershell
+./scripts/ef-migrations.ps1 "AddCardsTable"
+```
+
+Bash:
+
+```bash
+./scripts/ef-migrations.sh "AddCardsTable"
+```
+
+### What the scripts do
+
+* Add a migration under `/Data/Migrations`.
+* Apply it to the local SQLite database.
+* Target .NET 9 and EF Core 9 tooling.
+
+### Visual Studio Package Manager Console alternative
+
+```powershell
+Set-Location .\api
+Add-Migration AddCardsTable -OutputDir Data\Migrations
+Update-Database
+```
+
+### Useful checks
+
+List available migrations:
+
+```bash
+dotnet ef migrations list --project ./api/api.csproj --startup-project ./api/api.csproj
+```
+
+Inspect the SQLite schema:
+
+```bash
+sqlite3 ./api/app.db ".schema"
+```
+
+> **Notes**
+>
+> * Always commit generated migration files.
+> * Run the scripts from the repository root so relative paths resolve correctly.
+> * Do not commit user-specific SQLite database files.

--- a/api/README.md
+++ b/api/README.md
@@ -9,7 +9,7 @@ Use the provided scripts from the repository root to keep migrations consistent 
 PowerShell:
 
 ```powershell
-./scripts/ef-migrations.ps1 "AddCardsTable"
+./api/scripts/ef-migrations.ps1 "AddCardsTable"
 ```
 
 Bash:

--- a/api/scripts/ef-migrations.ps1
+++ b/api/scripts/ef-migrations.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Adds a new Entity Framework Core migration and applies it to the local SQLite database.
+
+.DESCRIPTION
+    Run from the repository root.
+    Windows Terminal / PowerShell: ./api/scripts/ef-migrations.ps1 "MigrationName"
+    Visual Studio Package Manager Console:
+        Set-Location .\api
+        ./scripts/ef-migrations.ps1 "MigrationName"
+#>
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$MigrationName
+)
+
+if (-not $MigrationName) {
+    Write-Error "Usage: ./api/scripts/ef-migrations.ps1 \"MigrationName\""
+    exit 1
+}
+
+$ErrorActionPreference = 'Stop'
+$projectPath = './api/api.csproj'
+$commands = @(
+    @('dotnet', 'ef', 'migrations', 'add', $MigrationName, '--project', $projectPath, '--startup-project', $projectPath, '--output-dir', 'Data/Migrations'),
+    @('dotnet', 'ef', 'database', 'update', '--project', $projectPath, '--startup-project', $projectPath)
+)
+
+foreach ($command in $commands) {
+    $commandDisplay = $command -join ' '
+    Write-Host "Executing: $commandDisplay"
+    try {
+        if ($command.Length -gt 1) {
+            & $command[0] @($command[1..($command.Length - 1)])
+        }
+        else {
+            & $command[0]
+        }
+    }
+    catch {
+        Write-Error "Command failed: $commandDisplay"
+        throw
+    }
+}

--- a/api/scripts/ef-migrations.sh
+++ b/api/scripts/ef-migrations.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  >&2 echo "Usage: ./api/scripts/ef-migrations.sh \"MigrationName\""
+  exit 2
+fi
+
+migration_name="$1"
+project_path="./api/api.csproj"
+
+echo "Executing: dotnet ef migrations add ${migration_name} --project ${project_path} --startup-project ${project_path} --output-dir Data/Migrations"
+dotnet ef migrations add "${migration_name}" --project "${project_path}" --startup-project "${project_path}" --output-dir "Data/Migrations"
+
+echo "Executing: dotnet ef database update --project ${project_path} --startup-project ${project_path}"
+dotnet ef database update --project "${project_path}" --startup-project "${project_path}"


### PR DESCRIPTION
## Summary
- add PowerShell and Bash helper scripts to generate and apply EF Core migrations from the repo root
- document Entity Framework migration workflows, including CLI scripts and Visual Studio Package Manager Console usage
- ensure the Data/Migrations folder stays tracked for newly generated migrations

## Testing
- `dotnet build api/api.csproj -c Release` *(fails in container: `dotnet` CLI not available)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cc075518832fbef4900de241ee8b