### PR TITLE
Add SQLite-backed API integration tests for core endpoints

### DIFF
--- a/api.Tests/Availability/AvailabilityTests.cs
+++ b/api.Tests/Availability/AvailabilityTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using FluentAssertions;
+using api.Tests.Infrastructure;
+
+namespace api.Tests.Availability;
+
+public class AvailabilityTests(TestingWebAppFactory factory) : IClassFixture<TestingWebAppFactory>
+{
+    private readonly TestingWebAppFactory _factory = factory;
+
+    private async Task SeedDataAsync()
+    {
+        await _factory.ResetStateAsync();
+        await _factory.ExecuteDbContextAsync(Seed.SeedAsync);
+    }
+
+    [Fact]
+    public async Task CollectionAvailability_AccountsForDeckAssignments()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var payload = await client.GetFromJsonAsync<PagedResponse<CollectionItemContract>>("/api/collection");
+        payload.Should().NotBeNull();
+        var card = payload!.Items.Single(i => i.CardPrintingId == Seed.LightningBetaPrintingId);
+        card.QuantityOwned.Should().Be(3);
+        card.Availability.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeckCardsWithAvailability_ReturnCurrentDeckSnapshot()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync($"/api/decks/{Seed.AdminDeckId}/cards-with-availability");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<DeckCardAvailabilityContract>>();
+        items.Should().NotBeNull();
+        var card = items!.Single(i => i.PrintingId == Seed.LightningBetaPrintingId);
+        card.QuantityInDeck.Should().Be(2);
+        card.Availability.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task WishlistOnlyEntries_DoNotContributeToAvailability()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var payload = await client.GetFromJsonAsync<PagedResponse<CollectionItemContract>>("/api/collection");
+        payload.Should().NotBeNull();
+        var card = payload!.Items.Single(i => i.CardPrintingId == Seed.PhoenixPrintingId);
+        card.QuantityOwned.Should().Be(0);
+        card.QuantityWanted.Should().Be(2);
+        card.Availability.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AvailabilityReachesZeroWhenUsageMatchesOwnership()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var upsert = await client.PostAsJsonAsync($"/api/decks/{Seed.AdminDeckId}/cards/upsert", new
+        {
+            printingId = Seed.LightningBetaPrintingId,
+            qty = 3
+        });
+        upsert.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var snapshot = await client.GetFromJsonAsync<List<DeckCardAvailabilityContract>>($"/api/decks/{Seed.AdminDeckId}/cards-with-availability");
+        snapshot.Should().NotBeNull();
+        var card = snapshot!.Single(i => i.PrintingId == Seed.LightningBetaPrintingId);
+        card.QuantityInDeck.Should().Be(3);
+        card.Availability.Should().Be(0);
+
+        var over = await client.PostAsJsonAsync($"/api/decks/{Seed.AdminDeckId}/cards/quantity-delta", new
+        {
+            printingId = Seed.LightningBetaPrintingId,
+            qtyDelta = 1
+        });
+        over.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var message = await over.Content.ReadAsStringAsync();
+        message.Should().Contain("Insufficient availability");
+    }
+
+    private sealed record PagedResponse<T>(IReadOnlyList<T> Items, int Total, int Page, int PageSize);
+
+    private sealed record CollectionItemContract(int CardPrintingId, int QuantityOwned, int QuantityWanted, int QuantityProxyOwned, int Availability, int AvailabilityWithProxies, int CardId, string CardName, string Game, string Set, string Number, string Rarity, string Style, string? ImageUrl);
+
+    private sealed record DeckCardAvailabilityContract(int PrintingId, string CardName, string? ImageUrl, int QuantityInDeck, int Availability, int AvailabilityWithProxies);
+}

--- a/api.Tests/Collections/CollectionApiTests.cs
+++ b/api.Tests/Collections/CollectionApiTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using api.Tests.Infrastructure;
+
+namespace api.Tests.Collections;
+
+public class CollectionApiTests(TestingWebAppFactory factory) : IClassFixture<TestingWebAppFactory>
+{
+    private readonly TestingWebAppFactory _factory = factory;
+
+    private async Task SeedDataAsync()
+    {
+        await _factory.ResetStateAsync();
+        await _factory.ExecuteDbContextAsync(Seed.SeedAsync);
+    }
+
+    [Fact]
+    public async Task GetCollection_ForCurrentUser_ReturnsOnlyOwnedEntries()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync("/api/collection");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<PagedResponse<CollectionItemContract>>();
+        payload.Should().NotBeNull();
+        payload!.Items.Should().NotBeEmpty();
+        payload.Items.Select(i => i.CardPrintingId).Should().Contain(new[]
+        {
+            Seed.LightningAlphaPrintingId,
+            Seed.LightningBetaPrintingId,
+            Seed.PhoenixPrintingId,
+            Seed.GoblinPrintingId
+        });
+        payload.Items.Select(i => i.CardPrintingId).Should().NotContain(Seed.DragonPrintingId);
+    }
+
+    [Fact]
+    public async Task QuickAdd_IncrementsQuantityOwned()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/collection/items", new
+        {
+            printingId = Seed.GoblinPrintingId,
+            quantity = 2
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<QuickAddResponseContract>();
+        result.Should().NotBeNull();
+        result!.PrintingId.Should().Be(Seed.GoblinPrintingId);
+        result.QuantityOwned.Should().Be(3);
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var card = await db.UserCards.FindAsync(Seed.AdminUserId, Seed.GoblinPrintingId);
+            card.Should().NotBeNull();
+            card!.QuantityOwned.Should().Be(3);
+        });
+    }
+
+    [Fact]
+    public async Task PostCollection_WithInvalidQuantities_ReturnsValidationProblem()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/collection", new
+        {
+            cardPrintingId = Seed.GoblinPrintingId,
+            quantityOwned = -1,
+            quantityWanted = 0,
+            quantityProxyOwned = 0
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        problem.Should().NotBeNull();
+        problem!.Errors.Should().ContainKey("QuantityOwned");
+    }
+
+    [Fact]
+    public async Task DeleteCollectionItem_RemovesRow()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.DeleteAsync($"/api/collection/{Seed.LightningAlphaPrintingId}");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var card = await db.UserCards.FindAsync(Seed.AdminUserId, Seed.LightningAlphaPrintingId);
+            card.Should().BeNull();
+        });
+    }
+
+    private sealed record PagedResponse<T>(IReadOnlyList<T> Items, int Total, int Page, int PageSize);
+
+    private sealed record CollectionItemContract(int CardPrintingId, int QuantityOwned, int QuantityWanted, int QuantityProxyOwned, int Availability, int AvailabilityWithProxies, int CardId, string CardName, string Game, string Set, string Number, string Rarity, string Style, string? ImageUrl);
+
+    private sealed record QuickAddResponseContract(int PrintingId, int QuantityOwned);
+}

--- a/api.Tests/Decks/DecksApiTests.cs
+++ b/api.Tests/Decks/DecksApiTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using api.Tests.Infrastructure;
+
+namespace api.Tests.Decks;
+
+public class DecksApiTests(TestingWebAppFactory factory) : IClassFixture<TestingWebAppFactory>
+{
+    private readonly TestingWebAppFactory _factory = factory;
+
+    private async Task SeedDataAsync()
+    {
+        await _factory.ResetStateAsync();
+        await _factory.ExecuteDbContextAsync(Seed.SeedAsync);
+    }
+
+    [Fact]
+    public async Task CreateDeck_ReturnsCreatedDeck()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/deck", new
+        {
+            game = "Magic",
+            name = "Test Deck",
+            description = "Integration test deck"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+
+        var deck = await response.Content.ReadFromJsonAsync<DeckResponseContract>();
+        deck.Should().NotBeNull();
+        deck!.UserId.Should().Be(Seed.AdminUserId);
+        deck.Name.Should().Be("Test Deck");
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var stored = await db.Decks.FindAsync(deck.Id);
+            stored.Should().NotBeNull();
+            stored!.Name.Should().Be("Test Deck");
+        });
+    }
+
+    [Fact]
+    public async Task AddCardToDeck_AddsEntryAndReturnsAvailability()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync($"/api/decks/{Seed.AdminDeckId}/cards/upsert", new
+        {
+            printingId = Seed.GoblinPrintingId,
+            qty = 1
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<DeckCardAvailabilityContract>();
+        payload.Should().NotBeNull();
+        payload!.PrintingId.Should().Be(Seed.GoblinPrintingId);
+        payload.QuantityInDeck.Should().Be(1);
+        payload.Availability.Should().Be(0);
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var deckCard = await db.DeckCards.FirstOrDefaultAsync(dc => dc.DeckId == Seed.AdminDeckId && dc.CardPrintingId == Seed.GoblinPrintingId);
+            deckCard.Should().NotBeNull();
+            deckCard!.QuantityInDeck.Should().Be(1);
+        });
+    }
+
+    [Fact]
+    public async Task GetDeckById_ReturnsDeckForOwner()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync($"/api/deck/{Seed.AdminDeckId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var deck = await response.Content.ReadFromJsonAsync<DeckResponseContract>();
+        deck.Should().NotBeNull();
+        deck!.Id.Should().Be(Seed.AdminDeckId);
+        deck.UserId.Should().Be(Seed.AdminUserId);
+    }
+
+    [Fact]
+    public async Task GetDeckById_WithDifferentUser_ReturnsForbidden()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.SecondaryUserId);
+
+        var response = await client.GetAsync($"/api/deck/{Seed.AdminDeckId}");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task DeleteCardFromDeck_RemovesEntry()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        await client.PostAsJsonAsync($"/api/decks/{Seed.AdminDeckId}/cards/upsert", new { printingId = Seed.GoblinPrintingId, qty = 1 });
+        var response = await client.DeleteAsync($"/api/decks/{Seed.AdminDeckId}/cards/{Seed.GoblinPrintingId}");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var deckCard = await db.DeckCards.FirstOrDefaultAsync(dc => dc.DeckId == Seed.AdminDeckId && dc.CardPrintingId == Seed.GoblinPrintingId);
+            deckCard.Should().BeNull();
+        });
+    }
+
+    private sealed record DeckResponseContract(int Id, int UserId, string Game, string Name, string? Description, DateTime CreatedUtc, DateTime? UpdatedUtc);
+
+    private sealed record DeckCardAvailabilityContract(int PrintingId, string CardName, string? ImageUrl, int QuantityInDeck, int Availability, int AvailabilityWithProxies);
+}

--- a/api.Tests/Infrastructure/Seed.cs
+++ b/api.Tests/Infrastructure/Seed.cs
@@ -1,0 +1,232 @@
+using System.Threading.Tasks;
+using api.Data;
+using api.Models;
+
+namespace api.Tests.Infrastructure;
+
+public static class Seed
+{
+    public const int AdminUserId = 1;
+    public const int SecondaryUserId = 2;
+
+    public const int LightningCardId = 200;
+    public const int GoblinCardId = 201;
+    public const int PhoenixCardId = 202;
+    public const int DragonCardId = 203;
+
+    public const int LightningAlphaPrintingId = 3001;
+    public const int LightningBetaPrintingId = 3002;
+    public const int GoblinPrintingId = 3003;
+    public const int PhoenixPrintingId = 3004;
+    public const int DragonPrintingId = 3005;
+
+    public const int AdminDeckId = 4001;
+    public const int SecondaryDeckId = 5001;
+
+    public static async Task SeedAsync(AppDbContext db)
+    {
+        var admin = new User
+        {
+            Id = AdminUserId,
+            Username = "admin",
+            DisplayName = "Admin",
+            IsAdmin = true
+        };
+
+        var userTwo = new User
+        {
+            Id = SecondaryUserId,
+            Username = "user2",
+            DisplayName = "User Two",
+            IsAdmin = false
+        };
+
+        db.Users.AddRange(admin, userTwo);
+
+        var lightning = new Card
+        {
+            CardId = LightningCardId,
+            Game = "Magic",
+            Name = "Lightning Bolt",
+            CardType = "Instant"
+        };
+
+        var goblin = new Card
+        {
+            CardId = GoblinCardId,
+            Game = "Magic",
+            Name = "Goblin Guide",
+            CardType = "Creature"
+        };
+
+        var phoenix = new Card
+        {
+            CardId = PhoenixCardId,
+            Game = "Magic",
+            Name = "Flameborn Phoenix",
+            CardType = "Creature"
+        };
+
+        var dragon = new Card
+        {
+            CardId = DragonCardId,
+            Game = "Magic",
+            Name = "Shivan Dragon",
+            CardType = "Creature"
+        };
+
+        db.Cards.AddRange(lightning, goblin, phoenix, dragon);
+
+        db.CardPrintings.AddRange(
+            new CardPrinting
+            {
+                Id = LightningAlphaPrintingId,
+                CardId = LightningCardId,
+                Set = "Alpha",
+                Number = "A1",
+                Rarity = "Common",
+                Style = "Standard",
+                ImageUrl = "https://example.com/lightning-alpha.png"
+            },
+            new CardPrinting
+            {
+                Id = LightningBetaPrintingId,
+                CardId = LightningCardId,
+                Set = "Beta",
+                Number = "B2",
+                Rarity = "Uncommon",
+                Style = "Foil",
+                ImageUrl = "https://example.com/lightning-beta.png"
+            },
+            new CardPrinting
+            {
+                Id = GoblinPrintingId,
+                CardId = GoblinCardId,
+                Set = "Zendikar",
+                Number = "Z3",
+                Rarity = "Rare",
+                Style = "Standard",
+                ImageUrl = "https://example.com/goblin.png"
+            },
+            new CardPrinting
+            {
+                Id = PhoenixPrintingId,
+                CardId = PhoenixCardId,
+                Set = "Mythic Flames",
+                Number = "M4",
+                Rarity = "Mythic",
+                Style = "Standard",
+                ImageUrl = "https://example.com/phoenix.png"
+            },
+            new CardPrinting
+            {
+                Id = DragonPrintingId,
+                CardId = DragonCardId,
+                Set = "Legends",
+                Number = "L5",
+                Rarity = "Rare",
+                Style = "Standard",
+                ImageUrl = "https://example.com/dragon.png"
+            });
+
+        db.UserCards.AddRange(
+            new UserCard
+            {
+                UserId = AdminUserId,
+                CardPrintingId = LightningAlphaPrintingId,
+                QuantityOwned = 2,
+                QuantityWanted = 0,
+                QuantityProxyOwned = 0
+            },
+            new UserCard
+            {
+                UserId = AdminUserId,
+                CardPrintingId = LightningBetaPrintingId,
+                QuantityOwned = 3,
+                QuantityWanted = 1,
+                QuantityProxyOwned = 0
+            },
+            new UserCard
+            {
+                UserId = AdminUserId,
+                CardPrintingId = PhoenixPrintingId,
+                QuantityOwned = 0,
+                QuantityWanted = 2,
+                QuantityProxyOwned = 0
+            },
+            new UserCard
+            {
+                UserId = AdminUserId,
+                CardPrintingId = GoblinPrintingId,
+                QuantityOwned = 1,
+                QuantityWanted = 0,
+                QuantityProxyOwned = 0
+            },
+            new UserCard
+            {
+                UserId = SecondaryUserId,
+                CardPrintingId = LightningAlphaPrintingId,
+                QuantityOwned = 1,
+                QuantityWanted = 1,
+                QuantityProxyOwned = 0
+            },
+            new UserCard
+            {
+                UserId = SecondaryUserId,
+                CardPrintingId = LightningBetaPrintingId,
+                QuantityOwned = 4,
+                QuantityWanted = 0,
+                QuantityProxyOwned = 0
+            },
+            new UserCard
+            {
+                UserId = SecondaryUserId,
+                CardPrintingId = DragonPrintingId,
+                QuantityOwned = 2,
+                QuantityWanted = 1,
+                QuantityProxyOwned = 0
+            });
+
+        var adminDeck = new Deck
+        {
+            Id = AdminDeckId,
+            UserId = AdminUserId,
+            Game = "Magic",
+            Name = "Admin Main",
+            Description = "Primary testing deck"
+        };
+
+        var userTwoDeck = new Deck
+        {
+            Id = SecondaryDeckId,
+            UserId = SecondaryUserId,
+            Game = "Magic",
+            Name = "User Two Deck",
+            Description = "Secondary deck"
+        };
+
+        db.Decks.AddRange(adminDeck, userTwoDeck);
+
+        db.DeckCards.AddRange(
+            new DeckCard
+            {
+                DeckId = AdminDeckId,
+                CardPrintingId = LightningBetaPrintingId,
+                QuantityInDeck = 2,
+                QuantityIdea = 0,
+                QuantityAcquire = 0,
+                QuantityProxy = 0
+            },
+            new DeckCard
+            {
+                DeckId = SecondaryDeckId,
+                CardPrintingId = DragonPrintingId,
+                QuantityInDeck = 1,
+                QuantityIdea = 0,
+                QuantityAcquire = 0,
+                QuantityProxy = 0
+            });
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/api.Tests/Infrastructure/TestingWebAppFactory.cs
+++ b/api.Tests/Infrastructure/TestingWebAppFactory.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using System.Net.Http;
+using System.Linq;
+using api.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace api.Tests.Infrastructure;
+
+public sealed class TestingWebAppFactory : WebApplicationFactory<Program>
+{
+    private readonly SqliteConnection _connection;
+
+    public TestingWebAppFactory()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+            if (descriptor is not null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<AppDbContext>(options => options.UseSqlite(_connection));
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            db.Database.EnsureCreated();
+        });
+    }
+
+    public HttpClient CreateClientForUser(int userId)
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Add("X-User-Id", userId.ToString(CultureInfo.InvariantCulture));
+        return client;
+    }
+
+    public async Task ResetStateAsync()
+    {
+        _ = Server; // ensure host is built
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.EnsureDeletedAsync();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    public async Task ExecuteScopeAsync(Func<IServiceProvider, Task> action)
+    {
+        _ = Server;
+        using var scope = Services.CreateScope();
+        await action(scope.ServiceProvider);
+    }
+
+    public async Task<T> ExecuteScopeAsync<T>(Func<IServiceProvider, Task<T>> action)
+    {
+        _ = Server;
+        using var scope = Services.CreateScope();
+        return await action(scope.ServiceProvider);
+    }
+
+    public Task ExecuteDbContextAsync(Func<AppDbContext, Task> action)
+        => ExecuteScopeAsync(sp => action(sp.GetRequiredService<AppDbContext>()));
+
+    public Task<T> ExecuteDbContextAsync<T>(Func<AppDbContext, Task<T>> action)
+        => ExecuteScopeAsync(sp => action(sp.GetRequiredService<AppDbContext>()));
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+        {
+            _connection.Dispose();
+        }
+    }
+}

--- a/api.Tests/Users/UsersApiTests.cs
+++ b/api.Tests/Users/UsersApiTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using api.Tests.Infrastructure;
+
+namespace api.Tests.Users;
+
+public class UsersApiTests(TestingWebAppFactory factory) : IClassFixture<TestingWebAppFactory>
+{
+    private readonly TestingWebAppFactory _factory = factory;
+
+    private async Task SeedDataAsync()
+    {
+        await _factory.ResetStateAsync();
+        await _factory.ExecuteDbContextAsync(Seed.SeedAsync);
+    }
+
+    [Fact]
+    public async Task GetUsers_ReturnsSeededUsers()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync("/api/users");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<List<UserResponseContract>>();
+        payload.Should().NotBeNull();
+        payload!.Select(u => u.Id).Should().Contain(new[] { Seed.AdminUserId, Seed.SecondaryUserId });
+    }
+
+    [Fact]
+    public async Task GetUserById_ReturnsSingleUserAndMissingReturns404()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync($"/api/user/{Seed.AdminUserId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var user = await response.Content.ReadFromJsonAsync<UserResponseContract>();
+        user.Should().NotBeNull();
+        user!.Id.Should().Be(Seed.AdminUserId);
+        user.Username.Should().Be("admin");
+
+        var missing = await client.GetAsync("/api/user/9999");
+        missing.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateUser_ReturnsCreatedUserAndPersists()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/admin/users", new { name = "charlie" });
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+
+        var created = await response.Content.ReadFromJsonAsync<AdminUserResponseContract>();
+        created.Should().NotBeNull();
+        created!.Name.Should().Be("charlie");
+        created.Username.Should().Be("charlie");
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var stored = await db.Users.FindAsync(created.Id);
+            stored.Should().NotBeNull();
+            stored!.Username.Should().Be("charlie");
+        });
+    }
+
+    [Fact]
+    public async Task CreateUser_WithBlankName_ReturnsProblemDetails()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/admin/users", new { name = "" });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem.Should().NotBeNull();
+        problem!.Title.Should().Be("Name required");
+        problem.Detail.Should().NotBeNullOrWhiteSpace();
+    }
+
+    private sealed record UserResponseContract(int Id, string Username, string DisplayName, bool IsAdmin);
+
+    private sealed record AdminUserResponseContract(int Id, string Name, string Username, string DisplayName, bool IsAdmin, DateTime CreatedUtc);
+}

--- a/api.Tests/Wishlists/WishlistApiTests.cs
+++ b/api.Tests/Wishlists/WishlistApiTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using FluentAssertions;
+using api.Tests.Infrastructure;
+
+namespace api.Tests.Wishlists;
+
+public class WishlistApiTests(TestingWebAppFactory factory) : IClassFixture<TestingWebAppFactory>
+{
+    private readonly TestingWebAppFactory _factory = factory;
+
+    private async Task SeedDataAsync()
+    {
+        await _factory.ResetStateAsync();
+        await _factory.ExecuteDbContextAsync(Seed.SeedAsync);
+    }
+
+    [Fact]
+    public async Task GetWishlist_ReturnsOnlyCurrentUserEntries()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync("/api/wishlist");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<WishlistItemContract>>();
+        items.Should().NotBeNull();
+        items!.Select(i => i.CardPrintingId).Should().BeEquivalentTo(new[]
+        {
+            Seed.LightningBetaPrintingId,
+            Seed.PhoenixPrintingId
+        });
+    }
+
+    [Fact]
+    public async Task QuickAdd_AddsNewWishlistQuantity()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/wishlist/items", new
+        {
+            printingId = Seed.GoblinPrintingId,
+            quantity = 2
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<QuickAddResponseContract>();
+        result.Should().NotBeNull();
+        result!.PrintingId.Should().Be(Seed.GoblinPrintingId);
+        result.QuantityWanted.Should().Be(2);
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var card = await db.UserCards.FindAsync(Seed.AdminUserId, Seed.GoblinPrintingId);
+            card.Should().NotBeNull();
+            card!.QuantityWanted.Should().Be(2);
+        });
+    }
+
+    [Fact]
+    public async Task QuickAdd_ForExistingPrinting_AccumulatesQuantity()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        await client.PostAsJsonAsync("/api/wishlist/items", new { printingId = Seed.LightningBetaPrintingId, quantity = 2 });
+        var response = await client.PostAsJsonAsync("/api/wishlist/items", new { printingId = Seed.LightningBetaPrintingId, quantity = 1 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<QuickAddResponseContract>();
+        result.Should().NotBeNull();
+        result!.QuantityWanted.Should().Be(4); // initial 1 + 2 + 1
+    }
+
+    [Fact]
+    public async Task MoveToCollection_ReducesWishlistAndUpdatesOwned()
+    {
+        await SeedDataAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.PostAsJsonAsync("/api/wishlist/move-to-collection", new
+        {
+            cardPrintingId = Seed.PhoenixPrintingId,
+            quantity = 1,
+            useProxy = false
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<MoveToCollectionResponseContract>();
+        result.Should().NotBeNull();
+        result!.CardPrintingId.Should().Be(Seed.PhoenixPrintingId);
+        result.QuantityWanted.Should().Be(1);
+        result.QuantityOwned.Should().Be(1);
+        result.Availability.Should().Be(1);
+
+        await _factory.ExecuteDbContextAsync(async db =>
+        {
+            var card = await db.UserCards.FindAsync(Seed.AdminUserId, Seed.PhoenixPrintingId);
+            card.Should().NotBeNull();
+            card!.QuantityWanted.Should().Be(1);
+            card.QuantityOwned.Should().Be(1);
+        });
+    }
+
+    private sealed record WishlistItemContract(int CardPrintingId, int QuantityWanted, int CardId, string CardName, string Game, string Set, string Number, string Rarity, string Style, string? ImageUrl);
+
+    private sealed record QuickAddResponseContract(int PrintingId, int QuantityWanted);
+
+    private sealed record MoveToCollectionResponseContract(int CardPrintingId, int QuantityWanted, int QuantityOwned, int QuantityProxyOwned, int Availability, int AvailabilityWithProxies);
+}

--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -8,7 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -57,9 +57,10 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
-// DB migrate + seed
-using (var scope = app.Services.CreateScope())
+// DB migrate + seed (skip in dedicated testing environment)
+if (!app.Environment.IsEnvironment("Testing"))
 {
+    using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     db.Database.Migrate();
     DbSeeder.Seed(db);

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,17 @@
+# API Integration Tests
+
+## In-memory SQLite test host
+- `api.Tests/Infrastructure/TestingWebAppFactory` configures the API for integration tests using a single shared `SqliteConnection` opened against `Filename=:memory:`.
+- The factory replaces the normal `AppDbContext` registration with `UseSqlite(sharedConnection)` and builds the schema with `Database.EnsureCreated()`.
+- `Program.cs` skips production migrations and seeding when `ASPNETCORE_ENVIRONMENT` is `Testing`, allowing the test project to manage data explicitly.
+- `Seed.SeedAsync` populates a deterministic multi-user dataset that exercises collections, wishlists, decks, and availability rules.
+
+## Running the tests
+- From the command line run `dotnet test` at the repository root to execute the full suite (this is what CI uses).
+- In Visual Studio 2022 open the solution and run tests via **Test Explorer**; the integration fixtures light up automatically.
+
+## Adding new API tests
+- Create test classes under `api.Tests/<Area>` and depend on `TestingWebAppFactory` via `IClassFixture`.
+- Call `ResetStateAsync` followed by `ExecuteDbContextAsync(Seed.SeedAsync)` (or a custom seeder) at the start of each test to ensure isolation.
+- Use `CreateClientForUser(userId)` to obtain an `HttpClient` with the required `X-User-Id` header.
+- Prefer strongly typed DTO contracts (records) and `HttpClient` JSON helpers for assertions; `FluentAssertions` is available for expressive checks.


### PR DESCRIPTION
## Summary
- add a `TestingWebAppFactory` that wires the API to a shared in-memory SQLite database for integration tests
- seed deterministic multi-user data for collections, wishlists, decks, and availability scenarios
- add integration coverage for users, collection, wishlist, deck, and availability endpoints using the new fixture
- document the integration test setup and workflow in `docs/tests.md`

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d7376b74832f8e684e61d17db9e0