### PR TITLE
Centralize API problem details handling

### DIFF
--- a/api/Common/Errors/DefaultProblemDetailsFactory.cs
+++ b/api/Common/Errors/DefaultProblemDetailsFactory.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+
+namespace api.Common.Errors;
+
+public sealed class DefaultProblemDetailsFactory : ProblemDetailsFactory
+{
+    private readonly ProblemDetailsOptions _options;
+
+    public DefaultProblemDetailsFactory(IOptions<ProblemDetailsOptions> options)
+    {
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public override ProblemDetails CreateProblemDetails(
+        HttpContext httpContext,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null)
+    {
+        if (httpContext is null)
+        {
+            throw new ArgumentNullException(nameof(httpContext));
+        }
+
+        statusCode ??= StatusCodes.Status500InternalServerError;
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Type = type,
+            Detail = detail,
+            Instance = instance
+        };
+
+        ApplyDefaults(httpContext, problemDetails, statusCode.Value);
+
+        return problemDetails;
+    }
+
+    public override ValidationProblemDetails CreateValidationProblemDetails(
+        HttpContext httpContext,
+        ModelStateDictionary modelStateDictionary,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null)
+    {
+        if (httpContext is null)
+        {
+            throw new ArgumentNullException(nameof(httpContext));
+        }
+
+        if (modelStateDictionary is null)
+        {
+            throw new ArgumentNullException(nameof(modelStateDictionary));
+        }
+
+        statusCode ??= StatusCodes.Status400BadRequest;
+
+        var problemDetails = new ValidationProblemDetails(modelStateDictionary)
+        {
+            Status = statusCode,
+            Type = type,
+            Detail = detail,
+            Instance = instance,
+            Title = title
+        };
+
+        ApplyDefaults(httpContext, problemDetails, statusCode.Value);
+
+        return problemDetails;
+    }
+
+    private void ApplyDefaults(HttpContext httpContext, ProblemDetails problemDetails, int statusCode)
+    {
+        if (_options.ClientErrorMapping.TryGetValue(statusCode, out var clientErrorData))
+        {
+            problemDetails.Title ??= clientErrorData.Title;
+            problemDetails.Type ??= clientErrorData.Link;
+        }
+
+        if (ProblemTypes.TryGet(statusCode, out var problemType))
+        {
+            problemType.Apply(httpContext, problemDetails);
+        }
+        else if (problemDetails.Instance is null)
+        {
+            problemDetails.Instance = httpContext.Request.Path;
+        }
+
+        var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+        if (!string.IsNullOrEmpty(traceId))
+        {
+            problemDetails.Extensions["traceId"] = traceId;
+        }
+    }
+}

--- a/api/Common/Errors/DefaultProblemDetailsFactory.cs
+++ b/api/Common/Errors/DefaultProblemDetailsFactory.cs
@@ -13,7 +13,11 @@ public sealed class DefaultProblemDetailsFactory : ProblemDetailsFactory
 
     public DefaultProblemDetailsFactory(IOptions<ProblemDetailsOptions> options)
     {
-        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+        _options = options.Value;
     }
 
     public override ProblemDetails CreateProblemDetails(

--- a/api/Common/Errors/ProblemTypes.cs
+++ b/api/Common/Errors/ProblemTypes.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace api.Common.Errors;
+
+public static class ProblemTypes
+{
+    private static readonly IReadOnlyDictionary<int, ProblemType> Types = new Dictionary<int, ProblemType>
+    {
+        [StatusCodes.Status400BadRequest] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/bad-request",
+            "Bad Request",
+            StatusCodes.Status400BadRequest,
+            "The request parameters were invalid."),
+        [StatusCodes.Status404NotFound] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/not-found",
+            "Not Found",
+            StatusCodes.Status404NotFound,
+            "The requested resource could not be found."),
+        [StatusCodes.Status409Conflict] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/conflict",
+            "Conflict",
+            StatusCodes.Status409Conflict,
+            "A conflicting resource state was detected."),
+        [StatusCodes.Status500InternalServerError] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/internal-server-error",
+            "Internal Server Error",
+            StatusCodes.Status500InternalServerError,
+            "An unexpected error occurred while processing the request.")
+    };
+
+    public static ProblemType BadRequest => Types[StatusCodes.Status400BadRequest];
+    public static ProblemType NotFound => Types[StatusCodes.Status404NotFound];
+    public static ProblemType Conflict => Types[StatusCodes.Status409Conflict];
+    public static ProblemType InternalServerError => Types[StatusCodes.Status500InternalServerError];
+
+    public static bool TryGet(int statusCode, out ProblemType problemType) => Types.TryGetValue(statusCode, out problemType);
+}
+
+public sealed record ProblemType(string Type, string Title, int Status, string DefaultDetail)
+{
+    public void Apply(HttpContext httpContext, ProblemDetails problemDetails)
+    {
+        problemDetails.Type ??= Type;
+        problemDetails.Title ??= Title;
+        problemDetails.Status ??= Status;
+        problemDetails.Detail ??= DefaultDetail;
+
+        if (problemDetails.Instance is null)
+        {
+            problemDetails.Instance = httpContext.Request.Path;
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,10 +1,15 @@
 using api.Common;
+using api.Common.Errors;
 using api.Data;
 using api.Middleware;
 using api.Models;
 using api.Importing;
 using FluentValidation;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 var isSeedCommand = args.Length > 0 && string.Equals(args[0], "seed", StringComparison.OrdinalIgnoreCase);
@@ -13,9 +18,51 @@ var filteredArgs = isSeedCommand ? args[1..] : args;
 var builder = WebApplication.CreateBuilder(filteredArgs);
 
 // Services
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .ConfigureApiBehaviorOptions(options =>
+    {
+        options.SuppressMapClientErrors = true;
+        options.InvalidModelStateResponseFactory = context =>
+        {
+            var problemDetailsFactory = context.HttpContext.RequestServices
+                .GetRequiredService<ProblemDetailsFactory>();
+
+            var problemDetails = problemDetailsFactory.CreateValidationProblemDetails(
+                context.HttpContext,
+                context.ModelState);
+
+            return new ObjectResult(problemDetails)
+            {
+                StatusCode = problemDetails.Status ?? StatusCodes.Status400BadRequest,
+                ContentTypes = { "application/problem+json" }
+            };
+        };
+    });
 builder.Services.AddAutoMapper(typeof(Program).Assembly);
 builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+builder.Services.Configure<ProblemDetailsOptions>(options =>
+{
+    options.ClientErrorMapping[StatusCodes.Status400BadRequest] = new ClientErrorData
+    {
+        Link = ProblemTypes.BadRequest.Type,
+        Title = ProblemTypes.BadRequest.Title
+    };
+
+    options.ClientErrorMapping[StatusCodes.Status404NotFound] = new ClientErrorData
+    {
+        Link = ProblemTypes.NotFound.Type,
+        Title = ProblemTypes.NotFound.Title
+    };
+
+    options.ClientErrorMapping[StatusCodes.Status409Conflict] = new ClientErrorData
+    {
+        Link = ProblemTypes.Conflict.Type,
+        Title = ProblemTypes.Conflict.Title
+    };
+});
+
+builder.Services.AddSingleton<ProblemDetailsFactory, DefaultProblemDetailsFactory>();
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlite("Data Source=app.db"));
@@ -79,6 +126,22 @@ if (!app.Environment.IsEnvironment("Testing"))
 }
 
 // Pipeline
+app.UseExceptionHandler(errorApp =>
+{
+    errorApp.Run(async context =>
+    {
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        context.Response.ContentType = "application/problem+json";
+
+        var problemDetailsFactory = context.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+        var problemDetails = problemDetailsFactory.CreateProblemDetails(
+            context,
+            context.Response.StatusCode);
+
+        await context.Response.WriteAsJsonAsync(problemDetails);
+    });
+});
+
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -62,7 +62,7 @@ builder.Services.Configure<ProblemDetailsOptions>(options =>
     };
 });
 
-builder.Services.AddSingleton<ProblemDetailsFactory, DefaultProblemDetailsFactory>();
+builder.Services.AddScoped<ProblemDetailsFactory, DefaultProblemDetailsFactory>();
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlite("Data Source=app.db"));


### PR DESCRIPTION
## Summary
- add a reusable problem details factory with consistent metadata and trace identifiers
- configure MVC to return enriched validation problem details for bad requests
- wire up exception handling so unhandled errors use the shared RFC 7807 formatter

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e64d8d0ddc832fb5554b55492decd6