### PR TITLE
Restore consistent RFC7807 responses for client errors

### DIFF
--- a/api.Tests/ProblemDetailsResponseTests.cs
+++ b/api.Tests/ProblemDetailsResponseTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using api.Common.Errors;
+using api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace api.Tests;
+
+public class ProblemDetailsResponseTests(TestingWebAppFactory factory) : IClassFixture<TestingWebAppFactory>
+{
+    private readonly TestingWebAppFactory _factory = factory;
+
+    private async Task SeedAsync()
+    {
+        await _factory.ResetStateAsync();
+        await _factory.ExecuteDbContextAsync(Seed.SeedAsync);
+    }
+
+    [Fact]
+    public async Task InvalidQuery_ReturnsValidationProblemDetailsWithTraceId()
+    {
+        await SeedAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync("/api/cards?skip=foo");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problem.Type.Should().Be(ProblemTypes.BadRequest.Type);
+        problem.Errors.Should().ContainKey("skip");
+        problem.Extensions.Should().ContainKey("traceId");
+        problem.Instance.Should().Be("/api/cards");
+    }
+
+    [Fact]
+    public async Task MissingResource_ReturnsNotFoundProblemDetails()
+    {
+        await SeedAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.GetAsync("/api/user/99999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be(StatusCodes.Status404NotFound);
+        problem.Type.Should().Be(ProblemTypes.NotFound.Type);
+        problem.Title.Should().Be(ProblemTypes.NotFound.Title);
+        problem.Detail.Should().NotBeNullOrWhiteSpace();
+        problem.Extensions.Should().ContainKey("traceId");
+        problem.Instance.Should().Be("/api/user/99999");
+    }
+
+    [Fact]
+    public async Task DeletingLastAdmin_ReturnsConflictProblemDetails()
+    {
+        await SeedAsync();
+        using var client = _factory.CreateClientForUser(Seed.AdminUserId);
+
+        var response = await client.DeleteAsync($"/api/admin/users/{Seed.AdminUserId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be(StatusCodes.Status409Conflict);
+        problem.Type.Should().Be(ProblemTypes.Conflict.Type);
+        problem.Title.Should().Be("Cannot remove last administrator");
+        problem.Detail.Should().Be("At least one administrator must remain.");
+        problem.Extensions.Should().ContainKey("traceId");
+        problem.Instance.Should().Be($"/api/admin/users/{Seed.AdminUserId}");
+    }
+}

--- a/api/Common/Errors/DefaultProblemDetailsFactory.cs
+++ b/api/Common/Errors/DefaultProblemDetailsFactory.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+
+namespace api.Common.Errors;
+
+public sealed class DefaultProblemDetailsFactory : ProblemDetailsFactory
+{
+    private readonly ProblemDetailsOptions _options;
+
+    public DefaultProblemDetailsFactory(IOptions<ProblemDetailsOptions> options)
+    {
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public override ProblemDetails CreateProblemDetails(
+        HttpContext httpContext,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null)
+    {
+        if (httpContext is null)
+        {
+            throw new ArgumentNullException(nameof(httpContext));
+        }
+
+        statusCode ??= StatusCodes.Status500InternalServerError;
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Type = type,
+            Detail = detail,
+            Instance = instance
+        };
+
+        ApplyDefaults(httpContext, problemDetails, statusCode.Value);
+
+        return problemDetails;
+    }
+
+    public override ValidationProblemDetails CreateValidationProblemDetails(
+        HttpContext httpContext,
+        ModelStateDictionary modelStateDictionary,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null)
+    {
+        if (httpContext is null)
+        {
+            throw new ArgumentNullException(nameof(httpContext));
+        }
+
+        if (modelStateDictionary is null)
+        {
+            throw new ArgumentNullException(nameof(modelStateDictionary));
+        }
+
+        statusCode ??= StatusCodes.Status400BadRequest;
+
+        var problemDetails = new ValidationProblemDetails(modelStateDictionary)
+        {
+            Status = statusCode,
+            Type = type,
+            Detail = detail,
+            Instance = instance,
+            Title = title
+        };
+
+        ApplyDefaults(httpContext, problemDetails, statusCode.Value);
+
+        return problemDetails;
+    }
+
+    private void ApplyDefaults(HttpContext httpContext, ProblemDetails problemDetails, int statusCode)
+    {
+        if (_options.ClientErrorMapping.TryGetValue(statusCode, out var clientErrorData))
+        {
+            problemDetails.Title ??= clientErrorData.Title;
+            problemDetails.Type ??= clientErrorData.Link;
+        }
+
+        if (ProblemTypes.TryGet(statusCode, out var problemType))
+        {
+            problemType.Apply(httpContext, problemDetails);
+        }
+        else if (problemDetails.Instance is null)
+        {
+            problemDetails.Instance = httpContext.Request.Path;
+        }
+
+        var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+        if (!string.IsNullOrEmpty(traceId))
+        {
+            problemDetails.Extensions["traceId"] = traceId;
+        }
+    }
+}

--- a/api/Common/Errors/ProblemTypes.cs
+++ b/api/Common/Errors/ProblemTypes.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace api.Common.Errors;
+
+public static class ProblemTypes
+{
+    private static readonly IReadOnlyDictionary<int, ProblemType> Types = new Dictionary<int, ProblemType>
+    {
+        [StatusCodes.Status400BadRequest] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/bad-request",
+            "Bad Request",
+            StatusCodes.Status400BadRequest,
+            "The request parameters were invalid."),
+        [StatusCodes.Status404NotFound] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/not-found",
+            "Not Found",
+            StatusCodes.Status404NotFound,
+            "The requested resource could not be found."),
+        [StatusCodes.Status409Conflict] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/conflict",
+            "Conflict",
+            StatusCodes.Status409Conflict,
+            "A conflicting resource state was detected."),
+        [StatusCodes.Status500InternalServerError] = new ProblemType(
+            "https://api.tradingcardgame.tracker/errors/internal-server-error",
+            "Internal Server Error",
+            StatusCodes.Status500InternalServerError,
+            "An unexpected error occurred while processing the request.")
+    };
+
+    public static ProblemType BadRequest => Types[StatusCodes.Status400BadRequest];
+    public static ProblemType NotFound => Types[StatusCodes.Status404NotFound];
+    public static ProblemType Conflict => Types[StatusCodes.Status409Conflict];
+    public static ProblemType InternalServerError => Types[StatusCodes.Status500InternalServerError];
+
+    public static bool TryGet(int statusCode, out ProblemType problemType) => Types.TryGetValue(statusCode, out problemType);
+}
+
+public sealed record ProblemType(string Type, string Title, int Status, string DefaultDetail)
+{
+    public void Apply(HttpContext httpContext, ProblemDetails problemDetails)
+    {
+        problemDetails.Type ??= Type;
+        problemDetails.Title ??= Title;
+        problemDetails.Status ??= Status;
+        problemDetails.Detail ??= DefaultDetail;
+
+        if (problemDetails.Instance is null)
+        {
+            problemDetails.Instance = httpContext.Request.Path;
+        }
+    }
+}

--- a/api/Features/Admin/Users/AdminUsersController.cs
+++ b/api/Features/Admin/Users/AdminUsersController.cs
@@ -38,13 +38,10 @@ public sealed class AdminUsersController : ControllerBase
     {
         if (request is null || string.IsNullOrWhiteSpace(request.Name))
         {
-            var problem = new ProblemDetails
-            {
-                Title = "Name required",
-                Detail = "A non-empty name is required to create a user.",
-                Status = StatusCodes.Status400BadRequest,
-            };
-            return BadRequest(problem);
+            return Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Name required",
+                detail: "A non-empty name is required to create a user.");
         }
 
         var name = request.Name.Trim();
@@ -66,7 +63,7 @@ public sealed class AdminUsersController : ControllerBase
     {
         if (request is null)
         {
-            return BadRequest();
+            return Problem(statusCode: StatusCodes.Status400BadRequest);
         }
 
         await using var tx = await _db.Database.BeginTransactionAsync();
@@ -84,13 +81,10 @@ public sealed class AdminUsersController : ControllerBase
             if (string.IsNullOrWhiteSpace(trimmedName))
             {
                 await tx.RollbackAsync();
-                var problem = new ProblemDetails
-                {
-                    Title = "Name required",
-                    Detail = "Name cannot be blank.",
-                    Status = StatusCodes.Status400BadRequest,
-                };
-                return BadRequest(problem);
+                return Problem(
+                    statusCode: StatusCodes.Status400BadRequest,
+                    title: "Name required",
+                    detail: "Name cannot be blank.");
             }
 
             user.Username = trimmedName;
@@ -159,15 +153,11 @@ public sealed class AdminUsersController : ControllerBase
             user.CreatedUtc);
     }
 
-    private static ObjectResult LastAdminConflict()
+    private IActionResult LastAdminConflict()
     {
-        var problem = new ProblemDetails
-        {
-            Title = "Cannot remove last administrator",
-            Detail = "At least one administrator must remain.",
-            Status = StatusCodes.Status409Conflict,
-        };
-
-        return new ObjectResult(problem) { StatusCode = StatusCodes.Status409Conflict };
+        return Problem(
+            statusCode: StatusCodes.Status409Conflict,
+            title: "Cannot remove last administrator",
+            detail: "At least one administrator must remain.");
     }
 }

--- a/api/Filters/RequireAdminAttribute.cs
+++ b/api/Filters/RequireAdminAttribute.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using api.Middleware;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace api.Filters;
 
@@ -17,13 +19,17 @@ public sealed class RequireAdminAttribute : Attribute, IAsyncActionFilter
             return;
         }
 
-        var problem = new ProblemDetails
-        {
-            Title = "Forbidden",
-            Detail = "Administrator access required.",
-            Status = StatusCodes.Status403Forbidden,
-        };
+        var factory = context.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+        var problem = factory.CreateProblemDetails(
+            context.HttpContext,
+            statusCode: StatusCodes.Status403Forbidden,
+            title: "Forbidden",
+            detail: "Administrator access required.");
 
-        context.Result = new ObjectResult(problem) { StatusCode = StatusCodes.Status403Forbidden };
+        context.Result = new ObjectResult(problem)
+        {
+            StatusCode = StatusCodes.Status403Forbidden,
+            ContentTypes = { "application/problem+json" }
+        };
     }
 }


### PR DESCRIPTION
## Summary
- re-enable MVC client error mapping so controller helpers return RFC 7807 payloads with trace identifiers
- route admin-only errors through the shared ProblemDetails factory for consistent formatting
- add integration tests covering 400, 404, and 409 responses to assert application/problem+json output

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e64d8d0ddc832fb5554b55492decd6