### PR TITLE
Normalize API problem responses

### DIFF
--- a/api/Common/Errors/ProblemDetailsFactoryExtensions.cs
+++ b/api/Common/Errors/ProblemDetailsFactoryExtensions.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace api.Common.Errors;
+
+public static class ProblemDetailsFactoryExtensions
+{
+    private const string ProblemContentType = "application/problem+json";
+
+    public static ObjectResult CreateProblem(
+        this ProblemDetailsFactory factory,
+        HttpContext httpContext,
+        int statusCode,
+        string? title = null,
+        string? detail = null,
+        string? type = null,
+        string? instance = null)
+    {
+        var problem = factory.CreateProblemDetails(httpContext, statusCode, title, type, detail, instance);
+        return CreateResult(statusCode, problem);
+    }
+
+    public static ObjectResult CreateValidationProblem(
+        this ProblemDetailsFactory factory,
+        HttpContext httpContext,
+        IDictionary<string, string[]> errors,
+        int statusCode = StatusCodes.Status400BadRequest,
+        string? title = null,
+        string? detail = null,
+        string? type = null,
+        string? instance = null)
+    {
+        var modelState = new ModelStateDictionary();
+
+        foreach (var (key, messages) in errors)
+        {
+            var field = key ?? string.Empty;
+            if (messages is { Length: > 0 })
+            {
+                foreach (var message in messages)
+                {
+                    modelState.AddModelError(field, message);
+                }
+            }
+            else
+            {
+                modelState.AddModelError(field, string.Empty);
+            }
+        }
+
+        var problem = factory.CreateValidationProblemDetails(httpContext, modelState, statusCode, title, type, detail, instance);
+        return CreateResult(statusCode, problem);
+    }
+
+    public static ObjectResult CreateProblem(
+        this ControllerBase controller,
+        int statusCode,
+        string? title = null,
+        string? detail = null,
+        string? type = null,
+        string? instance = null)
+    {
+        var factory = controller.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+        return factory.CreateProblem(controller.HttpContext, statusCode, title, detail, type, instance);
+    }
+
+    public static ObjectResult CreateValidationProblem(
+        this ControllerBase controller,
+        IDictionary<string, string[]> errors,
+        int statusCode = StatusCodes.Status400BadRequest,
+        string? title = null,
+        string? detail = null,
+        string? type = null,
+        string? instance = null)
+    {
+        var factory = controller.HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>();
+        return factory.CreateValidationProblem(controller.HttpContext, errors, statusCode, title, detail, type, instance);
+    }
+
+    public static ObjectResult CreateValidationProblem(
+        this ControllerBase controller,
+        string field,
+        params string[] errors)
+    {
+        return controller.CreateValidationProblem(new Dictionary<string, string[]> { [field] = errors });
+    }
+
+    private static ObjectResult CreateResult(int statusCode, ProblemDetails problem)
+    {
+        var result = new ObjectResult(problem)
+        {
+            StatusCode = statusCode
+        };
+
+        result.ContentTypes.Clear();
+        result.ContentTypes.Add(ProblemContentType);
+
+        return result;
+    }
+}

--- a/api/Common/Errors/ProblemDetailsFactoryExtensions.cs
+++ b/api/Common/Errors/ProblemDetailsFactoryExtensions.cs
@@ -38,17 +38,17 @@ public static class ProblemDetailsFactoryExtensions
 
         foreach (var (key, messages) in errors)
         {
-            var field = key ?? string.Empty;
+            var propertyName = key ?? string.Empty;
             if (messages is { Length: > 0 })
             {
                 foreach (var message in messages)
                 {
-                    modelState.AddModelError(field, message);
+                    modelState.AddModelError(propertyName, message);
                 }
             }
             else
             {
-                modelState.AddModelError(field, string.Empty);
+                modelState.AddModelError(propertyName, string.Empty);
             }
         }
 

--- a/api/Controllers/ImportExportController.cs
+++ b/api/Controllers/ImportExportController.cs
@@ -307,6 +307,7 @@ namespace api.Controllers
                     .ToListAsync();
                 var missing = allIds.Except(present).ToList();
                 if (missing.Count > 0)
+                {
                     var errors = new Dictionary<string, string[]>
                     {
                         ["cardPrintingId"] = new[]
@@ -317,6 +318,8 @@ namespace api.Controllers
 
                     return this.CreateValidationProblem(errors);
                 }
+
+            }
 
             using var trx = await _db.Database.BeginTransactionAsync();
 

--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -381,6 +381,17 @@ public class CollectionsController : ControllerBase
             .ToList();
 
         var result = await ApplyDeltaCore(userId, deltas);
+        // Restore previous behavior: convert NotFound (404) to BadRequest (400)
+        if (result is ObjectResult objectResult &&
+            objectResult.Value is ProblemDetails problemDetails &&
+            problemDetails.Status == StatusCodes.Status404NotFound)
+        {
+            // Convert to BadRequest (400)
+            return this.CreateProblem(
+                StatusCodes.Status400BadRequest,
+                title: problemDetails.Title ?? "Validation error",
+                detail: problemDetails.Detail ?? "A validation error occurred.");
+        }
         return result;
     }
 

--- a/api/Features/Prices/PricesController.cs
+++ b/api/Features/Prices/PricesController.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using api.Common.Errors;
 using api.Data;
 using api.Features.Prices.Dtos;
 using api.Middleware;
 using api.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,10 +28,16 @@ public sealed class PricesController(AppDbContext db) : ControllerBase
         int printingId,
         [FromQuery] int days = DefaultHistoryDays)
     {
-        if (printingId <= 0) return BadRequest("printingId must be positive.");
+        if (printingId <= 0)
+        {
+            return this.CreateValidationProblem("printingId", "printingId must be positive.");
+        }
 
         var exists = await _db.CardPrintings.AnyAsync(cp => cp.Id == printingId);
-        if (!exists) return NotFound();
+        if (!exists)
+        {
+            return this.CreateProblem(StatusCodes.Status404NotFound, detail: "Card printing not found.");
+        }
 
         if (days <= 0) days = DefaultHistoryDays;
 
@@ -60,10 +68,16 @@ public sealed class PricesController(AppDbContext db) : ControllerBase
         int cardId,
         [FromQuery] int days = DefaultHistoryDays)
     {
-        if (cardId <= 0) return BadRequest("cardId must be positive.");
+        if (cardId <= 0)
+        {
+            return this.CreateValidationProblem("cardId", "cardId must be positive.");
+        }
 
         var cardExists = await _db.Cards.AnyAsync(c => c.CardId == cardId);
-        if (!cardExists) return NotFound();
+        if (!cardExists)
+        {
+            return this.CreateProblem(StatusCodes.Status404NotFound, detail: "Card not found.");
+        }
 
         if (days <= 0) days = DefaultHistoryDays;
 
@@ -99,7 +113,13 @@ public sealed class PricesController(AppDbContext db) : ControllerBase
         [FromQuery] int days = DefaultValueHistoryDays)
     {
         var user = HttpContext.GetCurrentUser();
-        if (user is null) return BadRequest("X-User-Id header required.");
+        if (user is null)
+        {
+            return this.CreateProblem(
+                StatusCodes.Status400BadRequest,
+                title: "Missing required header",
+                detail: "The X-User-Id header is required.");
+        }
 
         if (days <= 0) days = DefaultValueHistoryDays;
 
@@ -145,10 +165,16 @@ public sealed class PricesController(AppDbContext db) : ControllerBase
         int deckId,
         [FromQuery] int days = DefaultValueHistoryDays)
     {
-        if (deckId <= 0) return BadRequest("deckId must be positive.");
+        if (deckId <= 0)
+        {
+            return this.CreateValidationProblem("deckId", "deckId must be positive.");
+        }
 
         var deckExists = await _db.Decks.AnyAsync(d => d.Id == deckId);
-        if (!deckExists) return NotFound();
+        if (!deckExists)
+        {
+            return this.CreateProblem(StatusCodes.Status404NotFound, detail: "Deck not found.");
+        }
 
         if (days <= 0) days = DefaultValueHistoryDays;
 


### PR DESCRIPTION
## Summary
- add a shared helper for producing ProblemDetails and ValidationProblemDetails responses
- refactor user-facing controllers to use consistent problem responses for 400/404/409 cases
- update the user context middleware to emit application/problem+json when the X-User-Id header is missing

## Testing
- dotnet build *(fails: dotnet is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65499d810832fb0a9cf7911e3b502