### PR TITLE
Simplify TryParseLimit helper in admin import controller

### DIFF
--- a/api/Features/Admin/Import/AdminImportController.cs
+++ b/api/Features/Admin/Import/AdminImportController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using api.Common.Errors;
 using api.Filters;
 using api.Importing;
 using api.Middleware;
@@ -128,13 +129,16 @@ public sealed class AdminImportController : ControllerBase
     public async Task<ActionResult<ImportPreviewResponse>> DryRun(CancellationToken ct)
     {
         var parse = await ParseRequestAsync(ct);
-        if (parse.Problem is not null) return BadRequest(parse.Problem);
+        if (parse.Problem is not null) return parse.Problem;
         var request = parse.Request;
-        if (request is null) return BadRequest(new ProblemDetails { Title = "Invalid request.", Status = StatusCodes.Status400BadRequest });
+        if (request is null)
+        {
+            return this.CreateProblem(StatusCodes.Status400BadRequest, title: "Invalid request.");
+        }
 
         if (ValidateLimit(request.Limit, out var effectiveLimit) is { } limitProblem)
         {
-            return BadRequest(limitProblem);
+            return limitProblem;
         }
 
         var importer = request.Importer;
@@ -170,11 +174,16 @@ public sealed class AdminImportController : ControllerBase
         }
         catch (FileParserException ex)
         {
-            return CreateProblem(ex);
+            if (ex.Errors is not null)
+            {
+                return this.CreateValidationProblem(ex.Errors, title: ex.Message);
+            }
+
+            return this.CreateProblem(StatusCodes.Status400BadRequest, title: ex.Message);
         }
         catch (Exception ex)
         {
-            return BadRequest(new ProblemDetails { Title = "Import failed", Detail = ex.Message });
+            return this.CreateProblem(StatusCodes.Status400BadRequest, title: "Import failed", detail: ex.Message);
         }
 
         var response = BuildPreviewResponse(request, summary);
@@ -186,13 +195,16 @@ public sealed class AdminImportController : ControllerBase
     public async Task<ActionResult<ImportApplyResponse>> Apply(CancellationToken ct)
     {
         var parse = await ParseRequestAsync(ct);
-        if (parse.Problem is not null) return BadRequest(parse.Problem);
+        if (parse.Problem is not null) return parse.Problem;
         var request = parse.Request;
-        if (request is null) return BadRequest(new ProblemDetails { Title = "Invalid request.", Status = StatusCodes.Status400BadRequest });
+        if (request is null)
+        {
+            return this.CreateProblem(StatusCodes.Status400BadRequest, title: "Invalid request.");
+        }
 
         if (ValidateLimit(request.Limit, out var effectiveLimit) is { } limitProblem)
         {
-            return BadRequest(limitProblem);
+            return limitProblem;
         }
 
         var importer = request.Importer;
@@ -228,11 +240,16 @@ public sealed class AdminImportController : ControllerBase
         }
         catch (FileParserException ex)
         {
-            return CreateProblem(ex);
+            if (ex.Errors is not null)
+            {
+                return this.CreateValidationProblem(ex.Errors, title: ex.Message);
+            }
+
+            return this.CreateProblem(StatusCodes.Status400BadRequest, title: ex.Message);
         }
         catch (Exception ex)
         {
-            return BadRequest(new ProblemDetails { Title = "Import failed", Detail = ex.Message });
+            return this.CreateProblem(StatusCodes.Status400BadRequest, title: "Import failed", detail: ex.Message);
         }
 
         return Ok(new ImportApplyResponse(
@@ -244,25 +261,10 @@ public sealed class AdminImportController : ControllerBase
 
     private async Task<ParseRequestResult> ParseRequestAsync(CancellationToken ct)
     {
-        static bool TryParseLimit(string? raw, out int? value, out ProblemDetails? problem)
-        {
-            value = null;
-            problem = null;
-            if (string.IsNullOrWhiteSpace(raw)) return true;
-            if (int.TryParse(raw, out var parsed))
-            {
-                value = parsed;
-                return true;
-            }
-
-            problem = CreateInvalidLimitProblem();
-            return false;
-        }
-
         var queryLimitRaw = Request.Query.TryGetValue("limit", out var queryLimitValues)
             ? queryLimitValues.ToString()
             : null;
-        if (!TryParseLimit(queryLimitRaw, out var queryLimit, out var queryProblem))
+        if (!TryParseLimit(queryLimitRaw, out var queryLimit, out var queryProblem, this))
         {
             return new ParseRequestResult(null, queryProblem);
         }
@@ -276,7 +278,7 @@ public sealed class AdminImportController : ControllerBase
             var formLimitRaw = form.TryGetValue("limit", out var limitValues)
                 ? limitValues.ToString()
                 : null;
-            if (!TryParseLimit(formLimitRaw, out var limit, out var limitProblem))
+            if (!TryParseLimit(formLimitRaw, out var limit, out var limitProblem, this))
             {
                 return new ParseRequestResult(null, limitProblem);
             }
@@ -303,7 +305,7 @@ public sealed class AdminImportController : ControllerBase
             }
             catch (JsonException)
             {
-                return new ParseRequestResult(null, new ProblemDetails { Title = "Invalid request.", Status = StatusCodes.Status400BadRequest });
+                return new ParseRequestResult(null, this.CreateProblem(StatusCodes.Status400BadRequest, title: "Invalid request."));
             }
 
             if (payload is null || string.IsNullOrWhiteSpace(payload.Source)) return new ParseRequestResult(null, null);
@@ -415,35 +417,30 @@ public sealed class AdminImportController : ControllerBase
         return new ImportPreviewResponse(summaryPayload, rows.ToArray());
     }
 
-    private static ActionResult CreateProblem(FileParserException ex)
+    private static bool TryParseLimit(string? raw, out int? value, out ObjectResult? problem, AdminImportController controller)
     {
-        if (ex.Errors is not null)
+        value = null;
+        problem = null;
+        if (string.IsNullOrWhiteSpace(raw)) return true;
+        if (int.TryParse(raw, out var parsed))
         {
-            return new ObjectResult(new ValidationProblemDetails(ex.Errors)
-            {
-                Title = ex.Message,
-                Status = StatusCodes.Status400BadRequest,
-            }) { StatusCode = StatusCodes.Status400BadRequest };
+            value = parsed;
+            return true;
         }
 
-        return new ObjectResult(new ProblemDetails
-        {
-            Title = ex.Message,
-            Status = StatusCodes.Status400BadRequest,
-        }) { StatusCode = StatusCodes.Status400BadRequest };
+        problem = controller.CreateInvalidLimitProblem();
+        return false;
     }
 
-    private static ProblemDetails CreateInvalidLimitProblem()
+    private ObjectResult CreateInvalidLimitProblem()
     {
-        return new ProblemDetails
-        {
-            Title = "Invalid limit",
-            Detail = $"limit must be between {ImportingOptions.MinPreviewLimit} and {ImportingOptions.MaxPreviewLimit}",
-            Status = StatusCodes.Status400BadRequest,
-        };
+        return this.CreateProblem(
+            StatusCodes.Status400BadRequest,
+            title: "Invalid limit",
+            detail: $"limit must be between {ImportingOptions.MinPreviewLimit} and {ImportingOptions.MaxPreviewLimit}");
     }
 
-    private static ProblemDetails? ValidateLimit(int? requested, out int effectiveLimit)
+    private ObjectResult? ValidateLimit(int? requested, out int effectiveLimit)
     {
         if (requested is null)
         {
@@ -468,7 +465,7 @@ public sealed class AdminImportController : ControllerBase
         public int? Limit { get; init; }
     }
 
-    private sealed record ParseRequestResult(ResolvedImportRequest? Request, ProblemDetails? Problem);
+    private sealed record ParseRequestResult(ResolvedImportRequest? Request, ObjectResult? Problem);
 
     private sealed record ResolvedImportRequest(
         ISourceImporter Importer,


### PR DESCRIPTION
## Summary
- simplify the limit parsing helper by keeping TryParseLimit static and passing the controller instance when a validation problem is required
- remove the unnecessary local wrapper so invalid limit requests continue to return CreateInvalidLimitProblem payloads

## Testing
- `dotnet test api.Tests` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e6735155d4832f975d2ef0c14ced8e