### PR TITLE
Normalize validation problem responses

### DIFF
--- a/api.Tests/ProblemDetailsResponseTests.cs
+++ b/api.Tests/ProblemDetailsResponseTests.cs
@@ -142,7 +142,7 @@ public class ProblemDetailsResponseTests(TestingWebAppFactory factory) : IClassF
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
 
-        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
 
         problem.Should().NotBeNull();
         problem!.Type.Should().Be(ProblemTypes.BadRequest.Type);
@@ -150,6 +150,8 @@ public class ProblemDetailsResponseTests(TestingWebAppFactory factory) : IClassF
         problem.Status.Should().Be(StatusCodes.Status400BadRequest);
         problem.Detail.Should().Be(ProblemTypes.BadRequest.DefaultDetail);
         problem.Instance.Should().Be("/api/admin/import/dry-run");
+        problem.Errors.Should().ContainKey("request")
+            .WhoseValue.Should().Contain("The request body could not be parsed as JSON.");
         problem.Extensions.Should().ContainKey("traceId");
     }
 
@@ -165,14 +167,16 @@ public class ProblemDetailsResponseTests(TestingWebAppFactory factory) : IClassF
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
 
-        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
 
         problem.Should().NotBeNull();
         problem!.Type.Should().Be(ProblemTypes.BadRequest.Type);
         problem.Title.Should().Be("Invalid limit");
         problem.Status.Should().Be(StatusCodes.Status400BadRequest);
-        problem.Detail.Should().Be($"limit must be between {ImportingOptions.MinPreviewLimit} and {ImportingOptions.MaxPreviewLimit}");
+        problem.Detail.Should().Be(ProblemTypes.BadRequest.DefaultDetail);
         problem.Instance.Should().Be("/api/admin/import/dry-run");
+        problem.Errors.Should().ContainKey("limit")
+            .WhoseValue.Should().Contain($"limit must be between {ImportingOptions.MinPreviewLimit} and {ImportingOptions.MaxPreviewLimit}");
         problem.Extensions.Should().ContainKey("traceId");
     }
 

--- a/api/Features/Admin/Import/AdminImportController.cs
+++ b/api/Features/Admin/Import/AdminImportController.cs
@@ -133,7 +133,13 @@ public sealed class AdminImportController : ControllerBase
         var request = parse.Request;
         if (request is null)
         {
-            return this.CreateProblem(StatusCodes.Status400BadRequest, title: "Invalid request.");
+            return this.CreateValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["request"] = new[] { "A valid import request is required." }
+                },
+                title: "Invalid request.",
+                detail: ProblemTypes.BadRequest.DefaultDetail);
         }
 
         if (ValidateLimit(request.Limit, out var effectiveLimit) is { } limitProblem)
@@ -179,7 +185,12 @@ public sealed class AdminImportController : ControllerBase
                 return this.CreateValidationProblem(ex.Errors, title: ex.Message);
             }
 
-            return this.CreateProblem(StatusCodes.Status400BadRequest, title: ex.Message);
+            return this.CreateValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["file"] = new[] { ex.Message }
+                },
+                title: ex.Message);
         }
         catch (Exception ex)
         {
@@ -199,7 +210,13 @@ public sealed class AdminImportController : ControllerBase
         var request = parse.Request;
         if (request is null)
         {
-            return this.CreateProblem(StatusCodes.Status400BadRequest, title: "Invalid request.");
+            return this.CreateValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["request"] = new[] { "A valid import request is required." }
+                },
+                title: "Invalid request.",
+                detail: ProblemTypes.BadRequest.DefaultDetail);
         }
 
         if (ValidateLimit(request.Limit, out var effectiveLimit) is { } limitProblem)
@@ -245,7 +262,12 @@ public sealed class AdminImportController : ControllerBase
                 return this.CreateValidationProblem(ex.Errors, title: ex.Message);
             }
 
-            return this.CreateProblem(StatusCodes.Status400BadRequest, title: ex.Message);
+            return this.CreateValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["file"] = new[] { ex.Message }
+                },
+                title: ex.Message);
         }
         catch (Exception ex)
         {
@@ -305,7 +327,15 @@ public sealed class AdminImportController : ControllerBase
             }
             catch (JsonException)
             {
-                return new ParseRequestResult(null, this.CreateProblem(StatusCodes.Status400BadRequest, title: "Invalid request."));
+                return new ParseRequestResult(
+                    null,
+                    this.CreateValidationProblem(
+                        new Dictionary<string, string[]>
+                        {
+                            ["request"] = new[] { "The request body could not be parsed as JSON." }
+                        },
+                        title: "Invalid request.",
+                        detail: ProblemTypes.BadRequest.DefaultDetail));
             }
 
             if (payload is null || string.IsNullOrWhiteSpace(payload.Source)) return new ParseRequestResult(null, null);
@@ -453,10 +483,16 @@ public sealed class AdminImportController : ControllerBase
 
     private ObjectResult CreateInvalidLimitProblem()
     {
-        return this.CreateProblem(
-            StatusCodes.Status400BadRequest,
+        return this.CreateValidationProblem(
+            new Dictionary<string, string[]>
+            {
+                ["limit"] = new[]
+                {
+                    $"limit must be between {ImportingOptions.MinPreviewLimit} and {ImportingOptions.MaxPreviewLimit}"
+                }
+            },
             title: "Invalid limit",
-            detail: $"limit must be between {ImportingOptions.MinPreviewLimit} and {ImportingOptions.MaxPreviewLimit}");
+            detail: ProblemTypes.BadRequest.DefaultDetail);
     }
 
     private ObjectResult? ValidateLimit(int? requested, out int effectiveLimit)

--- a/api/Features/Cards/CardsController.cs
+++ b/api/Features/Cards/CardsController.cs
@@ -232,7 +232,11 @@ public class CardsController : ControllerBase
 
         if (dto is null)
         {
-            return this.CreateProblem(StatusCodes.Status400BadRequest, detail: "Printing payload is required.");
+            return this.CreateValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["request"] = new[] { "Printing payload is required." }
+                });
         }
 
         if (dto.CardId <= 0)

--- a/api/Features/Collections/CollectionsController.cs
+++ b/api/Features/Collections/CollectionsController.cs
@@ -369,10 +369,12 @@ public class CollectionsController : ControllerBase
     {
         if (request is null)
         {
-            return this.CreateProblem(
-                StatusCodes.Status400BadRequest,
-                title: "Invalid payload",
-                detail: "A request body is required.");
+            return this.CreateValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["request"] = new[] { "A request body is required." }
+                },
+                title: "Invalid payload");
         }
 
         var items = request.Items ?? Array.Empty<CollectionBulkUpdateItem>();


### PR DESCRIPTION
## Summary
- return validation problem responses with field-specific errors when the cards printing payload is missing
- return validation problem responses for bulk collection deltas and admin import requests, including JSON parse failures and invalid limits
- update problem details tests to expect validation problems with appropriate error keys

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6865202b0832f9f2cc7dbe28cfeb0