### PR TITLE
Refactor shared card quantity guards and queries

### DIFF
--- a/api.Tests/Features/Common/QuantityGuardsTests.cs
+++ b/api.Tests/Features/Common/QuantityGuardsTests.cs
@@ -1,0 +1,42 @@
+using api.Features._Common;
+using Xunit;
+
+namespace api.Tests.Features.Common;
+
+public class QuantityGuardsTests
+{
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(42, 42)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    public void Clamp_Int_ReturnsExpected(int input, int expected)
+    {
+        var result = QuantityGuards.Clamp(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(long.MinValue, 0)]
+    [InlineData(-1L, 0)]
+    [InlineData(0L, 0)]
+    [InlineData(1234L, 1234)]
+    [InlineData((long)int.MaxValue + 10, int.MaxValue)]
+    public void Clamp_Long_ReturnsExpected(long input, int expected)
+    {
+        var result = QuantityGuards.Clamp(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(10, 5, 15)]
+    [InlineData(10, -3, 7)]
+    [InlineData(int.MaxValue, 10, int.MaxValue)]
+    [InlineData(1, -10, 0)]
+    public void ClampDelta_PreventsOverflowAndUnderflow(int current, int delta, int expected)
+    {
+        var result = QuantityGuards.ClampDelta(current, delta);
+        Assert.Equal(expected, result);
+    }
+}

--- a/api/Features/_Common/QuantityGuards.cs
+++ b/api/Features/_Common/QuantityGuards.cs
@@ -1,0 +1,35 @@
+using api.Shared;
+
+namespace api.Features._Common;
+
+/// <summary>
+/// Provides helper guards for normalizing card quantity values across features.
+/// </summary>
+internal static class QuantityGuards
+{
+    internal const int MinimumQuantity = 0;
+    internal const int MaximumQuantity = int.MaxValue;
+
+    /// <summary>
+    /// Clamps the provided quantity to the non-negative range.
+    /// </summary>
+    internal static int Clamp(int value) => value < MinimumQuantity
+        ? MinimumQuantity
+        : value > MaximumQuantity
+            ? MaximumQuantity
+            : value;
+
+    /// <summary>
+    /// Clamps the provided quantity, accepting long inputs to prevent overflow.
+    /// </summary>
+    internal static int Clamp(long value) => value < MinimumQuantity
+        ? MinimumQuantity
+        : value > MaximumQuantity
+            ? MaximumQuantity
+            : (int)value;
+
+    /// <summary>
+    /// Adds a delta to a quantity and clamps the result within the supported range.
+    /// </summary>
+    internal static int ClampDelta(int current, int delta) => UserCardMath.AddClamped(current, delta);
+}

--- a/api/Features/_Common/QueryExtensions.cs
+++ b/api/Features/_Common/QueryExtensions.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using api.Features.Cards.Dtos;
+using api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Features._Common;
+
+/// <summary>
+/// Shared query helpers for card-centric controllers.
+/// </summary>
+internal static class QueryExtensions
+{
+    internal static IQueryable<UserCard> FilterByPrintingMetadata(
+        this IQueryable<UserCard> query,
+        string? game,
+        string? set,
+        string? rarity,
+        string? name,
+        int? cardPrintingId,
+        bool useCaseInsensitiveName)
+    {
+        if (!string.IsNullOrWhiteSpace(game))
+        {
+            var trimmed = game.Trim();
+            query = query.Where(uc => uc.CardPrinting.Card.Game == trimmed);
+        }
+
+        if (!string.IsNullOrWhiteSpace(set))
+        {
+            var trimmed = set.Trim();
+            query = query.Where(uc => uc.CardPrinting.Set == trimmed);
+        }
+
+        if (!string.IsNullOrWhiteSpace(rarity))
+        {
+            var trimmed = rarity.Trim();
+            query = query.Where(uc => uc.CardPrinting.Rarity == trimmed);
+        }
+
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            var pattern = $"%{name.Trim()}%";
+            query = useCaseInsensitiveName
+                ? query.Where(uc => EF.Functions.Like(
+                    EF.Functions.Collate(uc.CardPrinting.Card.Name, "NOCASE"),
+                    pattern))
+                : query.Where(uc => EF.Functions.Like(uc.CardPrinting.Card.Name, pattern));
+        }
+
+        if (cardPrintingId.HasValue)
+        {
+            query = query.Where(uc => uc.CardPrintingId == cardPrintingId.Value);
+        }
+
+        return query;
+    }
+
+    internal static IOrderedQueryable<UserCard> OrderByCardNameAndPrinting(this IQueryable<UserCard> query)
+        => query.OrderBy(uc => uc.CardPrinting.Card.Name).ThenBy(uc => uc.CardPrintingId);
+
+    internal static IQueryable<Card> ApplyCardSearchFilters(
+        this IQueryable<Card> query,
+        string? searchTerm,
+        IReadOnlyCollection<string> games,
+        IReadOnlyCollection<string> sets,
+        IReadOnlyCollection<string> rarities)
+    {
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            var term = searchTerm.Trim();
+            query = query.Where(c =>
+                EF.Functions.Like(c.Name, $"%{term}%") ||
+                EF.Functions.Like(c.CardType, $"%{term}%"));
+        }
+
+        if (games.Count > 0)
+        {
+            query = query.Where(c => games.Contains(c.Game));
+        }
+
+        if (sets.Count > 0)
+        {
+            query = query.Where(c => c.Printings.Any(p => sets.Contains(p.Set)));
+        }
+
+        if (rarities.Count > 0)
+        {
+            query = query.Where(c => c.Printings.Any(p => rarities.Contains(p.Rarity)));
+        }
+
+        return query;
+    }
+
+    internal static IQueryable<CardListItemResponse> SelectCardSummaries(
+        this IQueryable<Card> query,
+        string placeholderImage)
+        => query.Select(c => new CardListItemResponse
+        {
+            CardId = c.CardId,
+            Game = c.Game,
+            Name = c.Name,
+            CardType = c.CardType,
+            PrintingsCount = c.Printings.Count(),
+            Primary = c.Printings
+                .OrderByDescending(p => !string.IsNullOrEmpty(p.ImageUrl))
+                .ThenByDescending(p => p.Style == "Standard")
+                .ThenBy(p => p.Set)
+                .ThenBy(p => p.Number)
+                .ThenBy(p => p.Id)
+                .Select(p => new CardListItemResponse.PrimaryPrintingResponse
+                {
+                    Id = p.Id,
+                    Set = p.Set,
+                    Number = p.Number,
+                    Rarity = p.Rarity,
+                    Style = p.Style,
+                    ImageUrl = string.IsNullOrEmpty(p.ImageUrl) ? placeholderImage : p.ImageUrl
+                })
+                .FirstOrDefault()
+        });
+}


### PR DESCRIPTION
## Summary
- extract reusable quantity guards and shared query extensions under `api/Features/_Common`
- refactor cards, collections, and wishlists controllers to rely on the shared helpers and named pagination constants
- add unit coverage for the quantity guard helpers to keep clamping and overflow behavior well defined

## Testing
- ⚠️ `dotnet build ./api/api.sln -c Release` *(dotnet CLI is unavailable in the execution environment)*
- ⚠️ `dotnet test ./api/api.sln -c Release` *(dotnet CLI is unavailable in the execution environment)*
- ⚠️ `dotnet format ./api/api.sln --verify-no-changes` *(dotnet CLI is unavailable in the execution environment)*
- ⚠️ `for i in 1 2 3 4 5; do curl -s -w "%{time_total}\n" -o /dev/null "http://localhost:5073/api/cards?skip=0&take=60"; done` *(API host not running inside the container)*

## Invariants
- [x] No public API or routing changes were introduced
- [x] No Entity Framework migrations were added or modified
- [x] Existing JSON wire formats remain unchanged
- [x] GET /api/cards pagination path keeps the same projection and ordering semantics
- [x] Only new helper tests were added; existing expectations were preserved

------
https://chatgpt.com/codex/tasks/task_e_68e748e1d300832f9eefce5fd35ff5cb