### PR TITLE
Remove placeholder import success message

### DIFF
--- a/api/Importing/DiceMastersDbImporter.cs
+++ b/api/Importing/DiceMastersDbImporter.cs
@@ -47,8 +47,7 @@ public sealed class DiceMastersDbImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
 
         return await _db.WithDryRunAsync(options.DryRun, async () =>
@@ -158,8 +157,7 @@ public sealed class DiceMastersDbImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 

--- a/api/Importing/FabDbImporter.cs
+++ b/api/Importing/FabDbImporter.cs
@@ -72,8 +72,7 @@ public sealed class FabDbImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 

--- a/api/Importing/GuardiansLocalImporter.cs
+++ b/api/Importing/GuardiansLocalImporter.cs
@@ -94,8 +94,7 @@ public sealed class GuardiansLocalImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 

--- a/api/Importing/LorcanaJsonImporter.cs
+++ b/api/Importing/LorcanaJsonImporter.cs
@@ -49,8 +49,7 @@ public sealed class LorcanaJsonImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
         var setCode = options.SetCode?.Trim();

--- a/api/Importing/PokemonTcgImporter.cs
+++ b/api/Importing/PokemonTcgImporter.cs
@@ -69,8 +69,7 @@ public sealed class PokemonTcgImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 

--- a/api/Importing/ScryfallImporter.cs
+++ b/api/Importing/ScryfallImporter.cs
@@ -46,8 +46,7 @@ public sealed class ScryfallImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 

--- a/api/Importing/SwccgdbImporter.cs
+++ b/api/Importing/SwccgdbImporter.cs
@@ -50,8 +50,7 @@ public sealed class SwccgdbImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var url = $"api/public/cards/{Uri.EscapeDataString(setCode)}.json"; // returns array of cards
         var cards = await _http.GetFromJsonAsync<List<SwccgCard>>(url, Json, ct)

--- a/api/Importing/SwuDbImporter.cs
+++ b/api/Importing/SwuDbImporter.cs
@@ -51,8 +51,7 @@ public sealed class SwuDbImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 

--- a/api/Importing/TransformersFmImporter.cs
+++ b/api/Importing/TransformersFmImporter.cs
@@ -53,8 +53,7 @@ public sealed class TransformersFmImporter : ISourceImporter
             CardsUpdated = 0,
             PrintingsCreated = 0,
             PrintingsUpdated = 0,
-            Errors = 0,
-            Messages = { "Dummy importer ran" }
+            Errors = 0
         };
         var limit = options.Limit ?? int.MaxValue;
 


### PR DESCRIPTION
## Summary
- remove the placeholder "Dummy importer ran" info message from each production importer
- rely on source-specific completion messages so the admin preview only shows real notes and errors

## Testing
- dotnet test api.Tests/api.Tests.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a75de4e4832fa6ae9aad4faae097