### PR TITLE
Fix formatting by removing extra closing braces

### DIFF
--- a/api/Migrations/20251005180000_AddUserPasswordHash.Designer.cs
+++ b/api/Migrations/20251005180000_AddUserPasswordHash.Designer.cs
@@ -364,5 +364,3 @@ namespace api.Migrations
         }
     }
 }
-    }
-}


### PR DESCRIPTION
Remove unnecessary closing braces from the migration file.