### PR TITLE
Fix test logger BeginScope signature

### DIFF
--- a/api.Tests/Features/AdminImport/AdminImportControllerTests.cs
+++ b/api.Tests/Features/AdminImport/AdminImportControllerTests.cs
@@ -360,7 +360,7 @@ public sealed class AdminImportControllerTests(CustomWebApplicationFactory facto
             ConcurrentQueue<TestLogEntry> sink,
             Func<IExternalScopeProvider> scopeProviderAccessor) : ILogger
         {
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => scopeProviderAccessor().Push(state!);
+            public IDisposable BeginScope<TState>(TState state) => scopeProviderAccessor().Push(state!);
 
             public bool IsEnabled(LogLevel logLevel) => true;
 


### PR DESCRIPTION
## Summary
- restore the test logger's BeginScope signature so it matches ILogger's unconstrained method

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e90c815874832fb59f9eef51dd31c4