### PR TITLE
Add helper to create authenticated test clients

### DIFF
--- a/api.Tests/Fixtures/CustomWebApplicationFactory.cs
+++ b/api.Tests/Fixtures/CustomWebApplicationFactory.cs
@@ -1,4 +1,6 @@
 using api.Data;
+using api.Tests;
+using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
@@ -51,4 +53,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         await db.Database.MigrateAsync();
         await TestDataSeeder.SeedAsync(db);
     }
+
+    public HttpClient CreateClientForUser(int userId)
+        => CreateClient().WithUser(userId);
 }


### PR DESCRIPTION
## Summary
- add a CreateClientForUser helper on the test web application factory that reuses the existing WithUser extension

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e91e44d010832f8301e43b7a4e3d86