### PR TITLE
Remove unused collection DTO import from wishlist controller tests

### DIFF
--- a/api.Tests/WishlistControllerTests.cs
+++ b/api.Tests/WishlistControllerTests.cs
@@ -2,7 +2,6 @@
 // Validates /api/wishlist endpoints and legacy routes via full HTTP calls.
 
 using api.Data;
-using api.Features.Collections.Dtos;
 using api.Features.Wishlists.Dtos;
 using api.Shared;
 using api.Tests.Fixtures;


### PR DESCRIPTION
## Summary
- remove the collection DTO using directive from the wishlist controller integration tests so only wishlist DTOs stay in scope

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e921d76c94832fa2192dae6eba23ad