### PR TITLE
Add MVC namespace for admin guard tests

### DIFF
--- a/api.Tests/AdminGuardAttributeTests.cs
+++ b/api.Tests/AdminGuardAttributeTests.cs
@@ -3,6 +3,7 @@ using api.Filters;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;


### PR DESCRIPTION
## Summary
- import Microsoft.AspNetCore.Mvc in the admin guard tests so MVC primitives resolve

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e922aea770832f8cd01c46c984c1f3