### PR TITLE
Add hosting namespace to JWT configuration tests

### DIFF
--- a/api.Tests/Authentication/JwtConfigurationTests.cs
+++ b/api.Tests/Authentication/JwtConfigurationTests.cs
@@ -2,6 +2,7 @@ using api.Authentication;
 using api.Data;
 using api.Models;
 using api.Tests.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Summary
- import the Microsoft.AspNetCore.Hosting namespace in the JWT configuration tests so the hosting extensions are available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9235c7a50832fa92bf26b43e1ec96