### PR TITLE
Allow nullable CORS collections

### DIFF
--- a/api/Infrastructure/Startup/CorsPolicyOptions.cs
+++ b/api/Infrastructure/Startup/CorsPolicyOptions.cs
@@ -8,18 +8,18 @@ internal sealed class CorsPolicyOptions
 
     public string PolicyName { get; set; } = "AllowReact";
 
-    public string[] Origins { get; set; } = new[]
+    public string[]? Origins { get; set; } = new[]
     {
         "http://localhost:5173"
     };
 
-    public string[] Headers { get; set; } = new[]
+    public string[]? Headers { get; set; } = new[]
     {
         "Authorization",
         "Content-Type"
     };
 
-    public string[] Methods { get; set; } = new[]
+    public string[]? Methods { get; set; } = new[]
     {
         "GET",
         "POST",


### PR DESCRIPTION
## Summary
- allow the CORS origins, headers, and methods configuration arrays to be nullable while keeping their default values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e924f208cc832fa4982a15c6195d6b