### PR TITLE
Fix logger usage in service collection extension tests

### DIFF
--- a/api.Tests/Infrastructure/Startup/ServiceCollectionExtensionsTests.cs
+++ b/api.Tests/Infrastructure/Startup/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using api.Infrastructure.Startup;
+using api.Tests.Features.AdminImport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Net;
@@ -42,7 +43,9 @@ public static class ServiceCollectionExtensionsTests
         var logger = loggerProvider.CreateLogger(typeof(ServiceCollectionExtensions).FullName!);
 
         var exception = Assert.Throws<FormatException>(() =>
-            ServiceCollectionExtensions.ParseKnownProxy("not-an-ip", "ForwardedHeaders:KnownProxies:0", logger));
+        {
+            ServiceCollectionExtensions.ParseKnownProxy("not-an-ip", "ForwardedHeaders:KnownProxies:0", logger);
+        });
 
         Assert.Contains("not-an-ip", exception.Message);
         Assert.Contains(loggerProvider.Entries, entry =>
@@ -55,7 +58,7 @@ public static class ServiceCollectionExtensionsTests
         var result = ServiceCollectionExtensions.ParseKnownProxy(
             "203.0.113.5",
             "ForwardedHeaders:KnownProxies:0",
-            NullLogger<ServiceCollectionExtensions>.Instance);
+            NullLogger.Instance);
 
         Assert.Equal(IPAddress.Parse("203.0.113.5"), result);
     }
@@ -71,11 +74,14 @@ public static class ServiceCollectionExtensionsTests
             PrefixLength = 24
         };
 
-        var exception = Assert.Throws<FormatException>(() => ServiceCollectionExtensions.ParseKnownNetwork(
-            entry,
-            "ForwardedHeaders:KnownNetworks:0:Prefix",
-            "ForwardedHeaders:KnownNetworks:0:PrefixLength",
-            logger));
+        var exception = Assert.Throws<FormatException>(() =>
+        {
+            ServiceCollectionExtensions.ParseKnownNetwork(
+                entry,
+                "ForwardedHeaders:KnownNetworks:0:Prefix",
+                "ForwardedHeaders:KnownNetworks:0:PrefixLength",
+                logger);
+        });
 
         Assert.Contains("invalid", exception.Message);
         Assert.Contains(loggerProvider.Entries, log =>
@@ -93,11 +99,14 @@ public static class ServiceCollectionExtensionsTests
             PrefixLength = 33
         };
 
-        var exception = Assert.Throws<FormatException>(() => ServiceCollectionExtensions.ParseKnownNetwork(
-            entry,
-            "ForwardedHeaders:KnownNetworks:0:Prefix",
-            "ForwardedHeaders:KnownNetworks:0:PrefixLength",
-            logger));
+        var exception = Assert.Throws<FormatException>(() =>
+        {
+            ServiceCollectionExtensions.ParseKnownNetwork(
+                entry,
+                "ForwardedHeaders:KnownNetworks:0:Prefix",
+                "ForwardedHeaders:KnownNetworks:0:PrefixLength",
+                logger);
+        });
 
         Assert.Contains("PrefixLength", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(loggerProvider.Entries, log =>
@@ -117,7 +126,7 @@ public static class ServiceCollectionExtensionsTests
             entry,
             "ForwardedHeaders:KnownNetworks:0:Prefix",
             "ForwardedHeaders:KnownNetworks:0:PrefixLength",
-            NullLogger<ServiceCollectionExtensions>.Instance);
+            NullLogger.Instance);
 
         Assert.Equal(IPAddress.Parse("2001:db8::"), result.Prefix);
         Assert.Equal(64, result.PrefixLength);


### PR DESCRIPTION
## Summary
- add the admin import test namespace to resolve the test logger provider
- switch service collection extension tests to use the non-generic null logger instance
- wrap FormatException assertions in block lambdas to avoid obsolete overloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e92da93c88832fa305ee06cdf1e017