### PR TITLE
Fix null assignment warning in auth tests

### DIFF
--- a/api.Tests/Features/Auth/AuthControllerTests.cs
+++ b/api.Tests/Features/Auth/AuthControllerTests.cs
@@ -21,7 +21,7 @@ public sealed class AuthControllerTests(CustomWebApplicationFactory factory)
         {
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
             var user = await db.Users.SingleAsync(u => u.Username == "alice");
-            user.PasswordHash = null;
+            user.PasswordHash = null!;
             await db.SaveChangesAsync();
         }
 


### PR DESCRIPTION
## Summary
- update the auth login test to use the null-forgiving operator when clearing the password hash so nullable analysis understands the intent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e92e972c18832fabaf1696bd1370f2