### PR TITLE
Enable XML documentation for test project

### DIFF
--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -4,6 +4,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- enable XML documentation generation for the test project
- suppress warning 1591 so missing XML comments do not break builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e92f579ab0832f824b9d1cbe6d0ff7