### PR TITLE
Use Assert.Single predicate overloads in tests

### DIFF
--- a/api.Tests/ImportExportControllerTests.cs
+++ b/api.Tests/ImportExportControllerTests.cs
@@ -115,7 +115,7 @@ public class ImportExportControllerTests(CustomWebApplicationFactory factory) : 
             Assert.Equal(payload.Decks.Count, decks.Count);
             foreach (var exportedDeck in payload.Decks)
             {
-                var deck = Assert.Single(decks.Where(d => d.Game == exportedDeck.Game && d.Name == exportedDeck.Name));
+                var deck = Assert.Single(decks, d => d.Game == exportedDeck.Game && d.Name == exportedDeck.Name);
                 Assert.Equal(exportedDeck.Description, deck.Description);
 
                 var expectedDeckCards = exportedDeck.Cards.OrderBy(c => c.CardPrintingId).ToList();

--- a/api.Tests/ValueControllerTests.cs
+++ b/api.Tests/ValueControllerTests.cs
@@ -140,10 +140,10 @@ public class ValueControllerTests(CustomWebApplicationFactory factory) : IClassF
         var expectedLorcana = 5678L * 1; // Alice owns one Elsa printing
         Assert.Equal(expectedMagic + expectedLorcana, summary!.totalCents);
 
-        var magicSlice = Assert.Single(summary.byGame.Where(s => s.game == "Magic"));
+        var magicSlice = Assert.Single(summary.byGame, s => s.game == "Magic");
         Assert.Equal(expectedMagic, magicSlice.cents);
 
-        var lorcanaSlice = Assert.Single(summary.byGame.Where(s => s.game == "Lorcana"));
+        var lorcanaSlice = Assert.Single(summary.byGame, s => s.game == "Lorcana");
         Assert.Equal(expectedLorcana, lorcanaSlice.cents);
     }
 

--- a/api.Tests/WishlistControllerTests.cs
+++ b/api.Tests/WishlistControllerTests.cs
@@ -93,9 +93,9 @@ public class WishlistControllerTests(CustomWebApplicationFactory factory) : ICla
 
         var items = await GetWishlistAsync(client, string.Empty);
         Assert.Equal(3, items.Count);
-        var mickey = Assert.Single(items.Where(i => i.CardPrintingId == TestDataSeeder.MickeyPrintingId));
+        var mickey = Assert.Single(items, i => i.CardPrintingId == TestDataSeeder.MickeyPrintingId);
         Assert.Equal(5, mickey.QuantityWanted);
-        var lightning = Assert.Single(items.Where(i => i.CardPrintingId == TestDataSeeder.LightningBoltAlphaPrintingId));
+        var lightning = Assert.Single(items, i => i.CardPrintingId == TestDataSeeder.LightningBoltAlphaPrintingId);
         Assert.Equal(2, lightning.QuantityWanted);
 
         var invalidResponse = await client.PutAsJsonAsync(


### PR DESCRIPTION
## Summary
- update wishlist, value, and import/export controller tests to use Assert.Single predicate overloads instead of pre-filtering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e92ff705f8832fbce41cac256a93f7