### PR TITLE
Fix logging test utilities for shared use in tests

### DIFF
--- a/api.Tests/Fixtures/CustomWebApplicationFactory.cs
+++ b/api.Tests/Fixtures/CustomWebApplicationFactory.cs
@@ -1,5 +1,4 @@
 using api.Data;
-using api.Tests;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.7.1" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary
- expose the logging test doubles at the namespace level so other test fixtures can consume them and keep scope provider fallback behavior safe
- add the missing Microsoft.Extensions.Logging.Abstractions dependency required by the shared test logger
- trim unused usings that were escalated to build errors

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e99eb2b5f0832f88123b6a99e3aef6