### PR TITLE
Remove unused Diagnostics using directive

### DIFF
--- a/api/Data/DbSeeder.cs
+++ b/api/Data/DbSeeder.cs
@@ -1,6 +1,5 @@
 using api.Models;
 using Microsoft.AspNetCore.Identity;
-using System.Diagnostics;
 
 namespace api.Data // Update to match your folder/namespace
 {


### PR DESCRIPTION
## Summary
- remove the unused System.Diagnostics using from DbSeeder

## Testing
- dotnet build api/api.csproj *(fails: `dotnet`: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e9a5442fb8832fb86e84ab477d1b20