### PR TITLE
Fix importer key mapping for admin imports

### DIFF
--- a/api.Tests/Features/AdminImport/AdminImportControllerSourceResolutionTests.cs
+++ b/api.Tests/Features/AdminImport/AdminImportControllerSourceResolutionTests.cs
@@ -1,0 +1,76 @@
+using api.Features.Admin.Import;
+using api.Importing;
+using api.Shared.Importing;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace api.Tests.Features.AdminImport;
+
+public sealed class AdminImportControllerSourceResolutionTests
+{
+    private static readonly (string Source, string ExpectedKey)[] KnownSourceMappings =
+    [
+        ("lorcanajson", "lorcanajson"),
+        ("fabdb", "fabdb"),
+        ("scryfall", "scryfall"),
+        ("swccgdb", "swccgdb"),
+        ("swu", "swu"),
+        ("pokemon", "pokemon"),
+        ("guardians", "guardians"),
+        ("dicemasters", "dicemasters"),
+        ("tftcg", "tftcg"),
+        ("dummy", "dummy"),
+    ];
+
+    public static IEnumerable<object[]> SourceMappings => KnownSourceMappings
+        .Select(mapping => new object[] { mapping.Source, mapping.ExpectedKey });
+
+    private static readonly MethodInfo TryResolveImporterMethod = typeof(AdminImportController)
+        .GetMethod("TryResolveImporter", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Unable to locate TryResolveImporter.");
+
+    [Theory]
+    [MemberData(nameof(SourceMappings))]
+    public void TryResolveImporter_WithKnownSources_ResolvesRegisteredImporter(string source, string expectedKey)
+    {
+        var controller = CreateController();
+        var parameters = new object?[] { source, null };
+
+        var resolved = (bool)TryResolveImporterMethod.Invoke(controller, parameters)!;
+
+        Assert.True(resolved);
+        var importer = Assert.IsAssignableFrom<ISourceImporter>(parameters[1]);
+        Assert.Equal(expectedKey, importer.Key);
+    }
+
+    private static AdminImportController CreateController()
+    {
+        var importers = KnownSourceMappings
+            .Select(mapping => (ISourceImporter)new StubImporter(mapping.ExpectedKey))
+            .ToArray();
+        var registry = new ImporterRegistry(importers);
+        return new AdminImportController(registry, new FileParser(), NullLogger<AdminImportController>.Instance);
+    }
+
+    private sealed class StubImporter(string key) : ISourceImporter
+    {
+        public string Key { get; } = key;
+
+        public string DisplayName => $"{key} importer";
+
+        public IEnumerable<string> SupportedGames => Array.Empty<string>();
+
+        public Task<ImportSummary> ImportFromRemoteAsync(ImportOptions options, CancellationToken ct = default)
+            => Task.FromResult(new ImportSummary { Source = Key });
+
+        public Task<ImportSummary> ImportFromFileAsync(Stream file, ImportOptions options, CancellationToken ct = default)
+            => Task.FromResult(new ImportSummary { Source = Key });
+    }
+}

--- a/api.Tests/Importing/ImporterRegistryTests.cs
+++ b/api.Tests/Importing/ImporterRegistryTests.cs
@@ -1,0 +1,46 @@
+using api.Importing;
+using api.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace api.Tests.Importing;
+
+public sealed class ImporterRegistryTests(CustomWebApplicationFactory factory) : IClassFixture<CustomWebApplicationFactory>
+{
+    private static readonly string[] ExpectedKeys =
+    [
+        "dicemasters",
+        "fabdb",
+        "guardians",
+        "lorcanajson",
+        "pokemon",
+        "scryfall",
+        "swccgdb",
+        "swu",
+        "tftcg",
+    ];
+
+    [Fact]
+    public void Registry_Resolves_Each_Importer_By_Key()
+    {
+        using var scope = factory.Services.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<ImporterRegistry>();
+
+        var actual = registry.Keys
+            .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var expected = ExpectedKeys
+            .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.Equal(expected, actual);
+
+        foreach (var key in ExpectedKeys)
+        {
+            Assert.True(registry.TryGet(key, out var importer));
+            Assert.Equal(key, importer.Key);
+        }
+    }
+}

--- a/api/Features/Admin/Import/AdminImportController.cs
+++ b/api/Features/Admin/Import/AdminImportController.cs
@@ -56,11 +56,11 @@ public sealed class AdminImportController : ControllerBase
         ["FabDb"] = "fabdb",
         ["Scryfall"] = "scryfall",
         ["Swccgdb"] = "swccgdb",
-        ["SwuDb"] = "swudb",
-        ["PokemonTcg"] = "pokemontcg",
-        ["GuardiansLocal"] = "guardianslocal",
-        ["DiceMastersDb"] = "dicemastersdb",
-        ["TransformersFm"] = "transformersfm",
+        ["SwuDb"] = "swu",
+        ["PokemonTcg"] = "pokemon",
+        ["GuardiansLocal"] = "guardians",
+        ["DiceMastersDb"] = "dicemasters",
+        ["TransformersFm"] = "tftcg",
         ["Dummy"] = "dummy",
     };
 


### PR DESCRIPTION
## Summary
- align canonical admin importer mappings with the keys exposed by each importer implementation
- add regression coverage to ensure admin import source resolution succeeds for every importer key
- verify the importer registry registers and resolves each importer by its expected key

## Testing
- dotnet test api.Tests/api.Tests.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e9c313e404832fb9ca33931c82b58a