### PR TITLE
Ensure logging abstractions are referenced in tests

### DIFF
--- a/api.Tests/Features/AdminImport/AdminImportControllerTests.cs
+++ b/api.Tests/Features/AdminImport/AdminImportControllerTests.cs
@@ -337,6 +337,7 @@ internal sealed record TestLogEntry(string Category, LogLevel Level, IReadOnlyLi
 internal sealed class TestLoggerProvider : ILoggerProvider, ISupportExternalScope
 {
     private readonly ConcurrentQueue<TestLogEntry> _entries = new();
+    // NullExternalScopeProvider lives in Microsoft.Extensions.Logging.Abstractions, so the package is required for this helper.
     private IExternalScopeProvider _scopeProvider = NullExternalScopeProvider.Instance;
 
     public IReadOnlyCollection<TestLogEntry> Entries => _entries.ToArray();

--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.7.1" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary
- pin the tests project to Microsoft.Extensions.Logging.Abstractions 9.0.0
- document why NullExternalScopeProvider is available and keep the helper using it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9d079d54c832f80c235f6850ea0ad