### PR TITLE
Remove redundant System.Net.Http using

### DIFF
--- a/api.Tests/Fixtures/CustomWebApplicationFactory.cs
+++ b/api.Tests/Fixtures/CustomWebApplicationFactory.cs
@@ -1,5 +1,5 @@
+// System.Net.Http implicit using provided by SDK; explicit directive removed.
 using api.Data;
-using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;


### PR DESCRIPTION
## Summary
- remove the explicit System.Net.Http using from the test factory
- document that implicit usings cover the directive

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e9d3641370832f8574206ee8df9813