### PR TITLE
Ensure dotnet tests run in Testing environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: dotnet build -c Release --no-restore -warnaserror
       - name: dotnet format check
         run: dotnet format api.sln --verify-no-changes --verbosity minimal
+      - name: Set test environment
+        run: echo "ASPNETCORE_ENVIRONMENT=Testing" >> $GITHUB_ENV
       - name: Test
         run: dotnet test -c Release --no-build --logger "trx;LogFileName=tests.trx"
       - name: Upload .NET test results

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,6 +10,8 @@ jobs:
           dotnet-version: '9.0.x'
       - run: dotnet restore ./api/api.sln
       - run: dotnet build   ./api/api.sln -c Release --no-restore
+      - name: Set test environment
+        run: echo "ASPNETCORE_ENVIRONMENT=Testing" >> $GITHUB_ENV
       - run: dotnet test    ./api/api.sln -c Release --no-build --logger "trx;LogFileName=test.trx" --results-directory TestResults
       - if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- set ASPNETCORE_ENVIRONMENT to Testing before running dotnet tests in ci workflow
- set ASPNETCORE_ENVIRONMENT to Testing before running dotnet tests in dotnet workflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebc28fd9d4832f8abe62c860035180