### PR TITLE
Fix password hash nullable migration ordering

### DIFF
--- a/api/Migrations/20251012140000_MakePasswordHashNullable.Designer.cs
+++ b/api/Migrations/20251012140000_MakePasswordHashNullable.Designer.cs
@@ -11,8 +11,8 @@ using api.Data;
 namespace api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20241116120000_AllowNullablePasswordHash")]
-    partial class AllowNullablePasswordHash
+    [Migration("20251012140000_MakePasswordHashNullable")]
+    partial class MakePasswordHashNullable
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/api/Migrations/20251012140000_MakePasswordHashNullable.cs
+++ b/api/Migrations/20251012140000_MakePasswordHashNullable.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace api.Migrations
 {
     /// <inheritdoc />
-    public partial class AllowNullablePasswordHash : Migration
+    public partial class MakePasswordHashNullable : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -22,13 +22,12 @@ namespace api.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            // Set any NULL password hashes to a placeholder value before making the column non-nullable
-            migrationBuilder.Sql("UPDATE \"Users\" SET \"PasswordHash\" = 'INVALID_HASH' WHERE \"PasswordHash\" IS NULL;");
             migrationBuilder.AlterColumn<string>(
                 name: "PasswordHash",
                 table: "Users",
                 type: "TEXT",
                 nullable: false,
+                defaultValue: "",
                 oldClrType: typeof(string),
                 oldType: "TEXT",
                 oldNullable: true);


### PR DESCRIPTION
## Summary
- remove the misordered AllowNullablePasswordHash migration that ran before the initial schema
- add a new MakePasswordHashNullable migration after Leonardo so Users.PasswordHash is nullable and the designer snapshot matches

## Testing
- dotnet ef database update --project api --startup-project api *(fails: `dotnet` CLI is not available in the execution environment)*
- dotnet test *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebcc4d33d0832f984a01362fbb203d