### PR TITLE
Use placeholder image for missing card printing URLs

### DIFF
--- a/api/Features/Cards/PrintingsController.cs
+++ b/api/Features/Cards/PrintingsController.cs
@@ -58,7 +58,7 @@ public sealed class PrintingsController : ControllerBase
                 null,
                 p.Number,
                 p.Rarity,
-                string.IsNullOrWhiteSpace(p.ImageUrl)
+                (p.ImageUrl == null || p.ImageUrl.Trim() == "")
                     ? "/images/placeholders/card-3x4.png"
                     : p.ImageUrl,
                 p.CardId,


### PR DESCRIPTION
## Summary
- ensure card printings default to the placeholder art when no image URL is stored

## Testing
- `dotnet build` *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebed41eb74832fbd07a3826b06b2a0