### PR TITLE
Add number filter for printings endpoint

### DIFF
--- a/api.Tests/Features/Cards/PrintingsControllerTests.cs
+++ b/api.Tests/Features/Cards/PrintingsControllerTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using api.Features.Cards.Dtos;
+using api.Tests;
+using api.Tests.Fixtures;
+using Xunit;
+
+namespace api.Tests.Features.Cards;
+
+public class PrintingsControllerTests(CustomWebApplicationFactory factory)
+    : IClassFixture<CustomWebApplicationFactory>
+{
+    [Fact]
+    public async Task Get_with_number_filters_to_exact_match()
+    {
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var result = await client.GetFromJsonAsync<List<PrintingDto>>("/api/cards/printings?number=A1");
+
+        var printings = Assert.NotNull(result);
+        var printing = Assert.Single(printings);
+        Assert.Equal(TestDataSeeder.LightningBoltAlphaPrintingId, printing.PrintingId);
+        Assert.Equal("A1", printing.Number);
+    }
+
+    [Fact]
+    public async Task Get_with_unknown_number_returns_empty_list()
+    {
+        using var client = factory.CreateClient().WithUser(TestDataSeeder.AliceUserId);
+
+        var result = await client.GetFromJsonAsync<List<PrintingDto>>("/api/cards/printings?number=UNKNOWN");
+
+        var printings = Assert.NotNull(result);
+        Assert.Empty(printings);
+    }
+}

--- a/api/Features/Cards/Dtos/ListPrintingsQuery.cs
+++ b/api/Features/Cards/Dtos/ListPrintingsQuery.cs
@@ -4,6 +4,7 @@ public sealed class ListPrintingsQuery
 {
     public string? Game { get; init; }
     public string? Set { get; init; }
+    public string? Number { get; init; }
     public string? Rarity { get; init; }
     public string? Style { get; init; }
     public string? Q { get; init; }           // name/number search

--- a/api/Features/Cards/PrintingsController.cs
+++ b/api/Features/Cards/PrintingsController.cs
@@ -26,6 +26,12 @@ public sealed class PrintingsController : ControllerBase
         if (!string.IsNullOrWhiteSpace(qp.Set))
             query = query.Where(p => p.Set == qp.Set);
 
+        if (!string.IsNullOrWhiteSpace(qp.Number))
+        {
+            var number = qp.Number.Trim();
+            query = query.Where(p => p.Number == number);
+        }
+
         if (!string.IsNullOrWhiteSpace(qp.Rarity))
             query = query.Where(p => p.Rarity == qp.Rarity);
 


### PR DESCRIPTION
## Summary
- allow the list printings query DTO to accept an optional card number filter
- apply an exact-match number predicate to the printings listing endpoint before ordering
- cover the new behaviour with integration tests for successful and empty number lookups

## Testing
- dotnet test *(fails: `dotnet` CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebf7573f28832f889636c4a44742a5