### PR TITLE
Use fetch for printings API

### DIFF
--- a/client-vite/src/features/printings/api/printings.ts
+++ b/client-vite/src/features/printings/api/printings.ts
@@ -35,5 +35,9 @@ export async function fetchPrintings(query: PrintingQuery): Promise<PrintingList
     const errorBody = await res.text();
     throw new Error(`Failed to fetch printings. Status: ${res.status} ${res.statusText}. Body: ${errorBody}`);
   }
-  return (await res.json()) as PrintingListItem[];
+  try {
+    return (await res.json()) as PrintingListItem[];
+  } catch (err) {
+    throw new Error(`Failed to parse printings response as JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }


### PR DESCRIPTION
## Summary
- replace the axios helper with a direct fetch call for printing lookups
- derive the API base from VITE_API_BASE and build query params via URLSearchParams

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed15bcf1dc832fafe4736908f13796