### PR TITLE
Remove layout width constraints from app shell

### DIFF
--- a/client-vite/src/App.css
+++ b/client-vite/src/App.css
@@ -1,8 +1,17 @@
+/* Root should not impose layout constraints. Individual pages control spacing. */
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  max-width: none;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  text-align: inherit;
+}
+
+/* Let the app shell manage layout; avoid global centering that fights page grid. */
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
 }
 
 .logo {

--- a/client-vite/src/app/AppShell.tsx
+++ b/client-vite/src/app/AppShell.tsx
@@ -6,7 +6,7 @@ export default function AppShell() {
     <div className="min-h-dvh flex flex-col">
       <Header />
       <main className="flex-1">
-        <div className="mx-auto w-full p-4">
+        <div className="w-full px-4 sm:px-6 py-4">
           <Outlet />
         </div>
       </main>

--- a/client-vite/src/components/app/Header.tsx
+++ b/client-vite/src/components/app/Header.tsx
@@ -100,7 +100,7 @@ export default function Header() {
 
   return (
     <header className="w-full border-b bg-background/60 backdrop-blur">
-      <div className="mx-auto w-full max-w-7xl p-4 space-y-3">
+      <div className="w-full px-4 sm:px-6 py-4 space-y-3">
         {/* Top row: brand, nav, user */}
         <div className="flex items-center gap-3">
           <div className="text-xl font-semibold">TCG Tracker</div>


### PR DESCRIPTION
## Summary
- remove global root width and padding limits so pages can expand fully
- update header and app shell wrappers to use fluid layouts with responsive horizontal padding

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ee573f3608832fb973cbd6314b9b22